### PR TITLE
Use new API `setState` and `getState` from the engine during fill processing

### DIFF
--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -13,7 +13,7 @@
     "@imgly/plugin-background-removal-web": "*",
     "@imgly/plugin-cutout-library-web": "*",
     "@imgly/plugin-remote-asset-source-web": "*",
-    "@cesdk/cesdk-js": "^1.21.0",
+    "@cesdk/cesdk-js": "^1.26.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/plugin-background-removal-web/package.json
+++ b/packages/plugin-background-removal-web/package.json
@@ -53,7 +53,7 @@
     "types:create": "tsc --emitDeclarationOnly"
   },
   "devDependencies": {
-    "@cesdk/cesdk-js": "^1.21.0",
+    "@cesdk/cesdk-js": "^1.26.0",
     "@types/ndarray": "^1.0.14",
     "chalk": "^5.3.0",
     "concurrently": "^8.2.2",
@@ -64,7 +64,7 @@
     "@imgly/plugin-utils": "*"
   },
   "peerDependencies": {
-    "@cesdk/cesdk-js": "^1.21.0"
+    "@cesdk/cesdk-js": "^1.26.0"
   },
   "dependencies": {
     "@imgly/background-removal": "^1.5.3"

--- a/packages/plugin-utils/package.json
+++ b/packages/plugin-utils/package.json
@@ -25,7 +25,7 @@
     "types:create": "tsc --emitDeclarationOnly"
   },
   "devDependencies": {
-    "@cesdk/cesdk-js": "^1.21.0",
+    "@cesdk/cesdk-js": "^1.26.0",
     "@types/ndarray": "^1.0.14",
     "chalk": "^5.3.0",
     "concurrently": "^8.2.2",
@@ -34,7 +34,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@cesdk/cesdk-js": "^1.21.0"
+    "@cesdk/cesdk-js": "^1.26.0"
   },
   "dependencies": {
     "lodash-es": "^4.17.21"

--- a/packages/plugin-utils/src/processing/initializeFillProcessing.ts
+++ b/packages/plugin-utils/src/processing/initializeFillProcessing.ts
@@ -40,7 +40,8 @@ export default function handleFillProcessing(
               cesdk.feature.unstable_isEnabled(featureId, {
                 engine: cesdk.engine
               }) &&
-              cesdk.engine.block.isAllowedByScope(id, 'fill/change')
+              cesdk.engine.block.isAllowedByScope(id, 'fill/change') &&
+              cesdk.engine.block.getState(id).type !== 'Pending'
             ) {
               process(id, metadata);
             }

--- a/packages/plugin-utils/src/processing/processFill.ts
+++ b/packages/plugin-utils/src/processing/processFill.ts
@@ -30,9 +30,7 @@ export default async function processFill(
   );
 
   try {
-    // Clear values in the engine to trigger the loading spinner
-    blockApi.setString(fillId, 'fill/image/imageFileURI', '');
-    blockApi.setSourceSet(fillId, 'fill/image/sourceSet', []);
+    cesdk.engine.block.setState(fillId, { type: 'Pending', progress: 0 });
 
     metadata.set(blockId, {
       ...metadata.get(blockId),
@@ -173,5 +171,7 @@ export default async function processFill(
 
     // eslint-disable-next-line no-console
     console.log(error);
+  } finally {
+    cesdk.engine.block.setState(fillId, { type: 'Ready' });
   }
 }

--- a/packages/plugin-utils/src/processing/registerFillProcessingComponents.ts
+++ b/packages/plugin-utils/src/processing/registerFillProcessingComponents.ts
@@ -60,7 +60,8 @@ export default function registerFillProcessingComponents(
       const isLoading = currentMetadata.status === 'PROCESSING';
       const isDisabled =
         currentMetadata.status === 'PENDING' ||
-        currentMetadata.status === 'PROCESSING';
+        currentMetadata.status === 'PROCESSING' ||
+        engine.block.getState(id)?.type === 'Pending';
 
       let loadingProgress: number | undefined;
       if (isLoading && currentMetadata.progress) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,6 +232,11 @@
   resolved "https://registry.yarnpkg.com/@cesdk/cesdk-js/-/cesdk-js-1.21.0.tgz#0420fe4752a1d094e967214ee143af032691ccb0"
   integrity sha512-BX6iRshiYPoIetCzt/4BX91jZnq6NswPLm9lk7jlypDpdCAgoXsJT/94HzKi8IglhmWo18Zzggdg9rw8Wc4noQ==
 
+"@cesdk/cesdk-js@^1.26.0":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/@cesdk/cesdk-js/-/cesdk-js-1.30.0.tgz#2c99516b3756f5d76ce2b15466ed7c3cb2399a9c"
+  integrity sha512-I7D/DoyOQlCB2186B0zZeX1Poov/MftaIq+6ddlFFXPWpKItRhfSEGR6WnPMZolsyOrMxGdAaiPCMqN8FFvVTg==
+
 "@esbuild/aix-ppc64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz#d1bc06aedb6936b3b6d313bf809a5a40387d2b7f"


### PR DESCRIPTION
Until this new API (introduces in CE.SDK 1.26) we had to use the fact that the engine shows loading spinner when no image file URI was set. We had to introduce some checks and recovering logic. 

This PR changes the state of the fill and does not process any fill if the block is not `Ready` as a general convention for plugins.

The checks and recovering logic is kept in there for now as it does not do any harm and will be removed in a following PR. 