### PR TITLE
Feature/plugin-cutout/improve-quality-for-png-images

### DIFF
--- a/packages/plugin-cutout-library-web/package.json
+++ b/packages/plugin-cutout-library-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-cutout-library-web",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.0",
   "description": "Cutout Library plugin for the CE.SDK editor",
   "keywords": [
     "CE.SDK",

--- a/packages/plugin-cutout-library-web/package.json
+++ b/packages/plugin-cutout-library-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-cutout-library-web",
-  "version": "1.0.2-rc.0",
+  "version": "1.0.2",
   "description": "Cutout Library plugin for the CE.SDK editor",
   "keywords": [
     "CE.SDK",


### PR DESCRIPTION
Improves the quality of cutouts when a png is used.
If the user is creating a cutout from a selection, and this selection contains images with mimetypes which could contain transparenct, we do not simplify the cutout.
