### PR TITLE
Fix/cutout plugin simplification parameter for transparency

### DIFF
--- a/packages/plugin-cutout-library-web/package.json
+++ b/packages/plugin-cutout-library-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-cutout-library-web",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cutout Library plugin for the CE.SDK editor",
   "keywords": [
     "CE.SDK",

--- a/packages/plugin-cutout-library-web/src/plugin.ts
+++ b/packages/plugin-cutout-library-web/src/plugin.ts
@@ -178,7 +178,7 @@ async function getSelectedMimeTypes(
       const isImageFill =
         fillBlockId != null &&
         engine.block.isValid(blockId) &&
-        engine.block.getType(blockId) === '//ly.img.ubq/fill/image';
+        engine.block.getType(fillBlockId) === '//ly.img.ubq/fill/image';
       if (!isImageFill) {
         return null;
       }


### PR DESCRIPTION
Fixes a bug that lead to contours of transparent images not being exact.