### PR TITLE
Fix: Make `plugin-qr-code-web` compatible with all new minor versions

### DIFF
--- a/packages/plugin-qr-code-web/package.json
+++ b/packages/plugin-qr-code-web/package.json
@@ -64,7 +64,7 @@
     "@imgly/plugin-utils": "*"
   },
   "peerDependencies": {
-    "@cesdk/cesdk-js": "1.37.0"
+    "@cesdk/cesdk-js": "^1.37.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Pinning the version makes installations with a newer CE.SDK version throw an error in NPM (not yarn)