### PR TITLE
Add Icons for Vectorizer & Background Removal

### DIFF
--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -14,7 +14,7 @@
     "@imgly/plugin-background-removal-web": "*",
     "@imgly/plugin-cutout-library-web": "*",
     "@imgly/plugin-remote-asset-source-web": "*",
-    "@cesdk/cesdk-js": "1.39.0",
+    "@cesdk/cesdk-js": "1.41.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/plugin-background-removal-web/package.json
+++ b/packages/plugin-background-removal-web/package.json
@@ -35,7 +35,13 @@
     }
   },
   "homepage": "https://img.ly/products/creative-sdk",
-  "files": ["LICENSE.md", "README.md", "CHANGELOG.md", "dist/", "bin/"],
+  "files": [
+    "LICENSE.md",
+    "README.md",
+    "CHANGELOG.md",
+    "dist/",
+    "bin/"
+  ],
   "scripts": {
     "start": "npm run watch",
     "clean": "npx rimraf dist",
@@ -53,14 +59,15 @@
     "types:create": "tsc --emitDeclarationOnly"
   },
   "devDependencies": {
+    "@imgly/plugin-utils": "*",
+    "@types/lodash-es": "^4.17.12",
     "@types/ndarray": "^1.0.14",
     "chalk": "^5.3.0",
     "concurrently": "^8.2.2",
     "esbuild": "^0.19.11",
     "eslint": "^8.51.0",
-    "typescript": "^5.3.3",
     "lodash-es": "^4.17.21",
-    "@imgly/plugin-utils": "*"
+    "typescript": "^5.3.3"
   },
   "peerDependencies": {
     "@cesdk/cesdk-js": "^1.32.0"

--- a/packages/plugin-background-removal-web/src/plugin.ts
+++ b/packages/plugin-background-removal-web/src/plugin.ts
@@ -3,7 +3,7 @@ import {
   registerFillProcessingComponents
 } from '@imgly/plugin-utils';
 
-import { EditorPlugin } from '@cesdk/cesdk-js';
+import CreativeEditorSDK, { EditorPlugin } from '@cesdk/cesdk-js';
 import {
   processBackgroundRemoval,
   type BackgroundRemovalProvider
@@ -23,6 +23,8 @@ export default (
   return {
     initialize({ cesdk }) {
       if (cesdk == null) return;
+
+      addIconSet(cesdk);
 
       initializeFillProcessing(cesdk, {
         pluginId: PLUGIN_ID,
@@ -52,3 +54,29 @@ export default (
     }
   };
 };
+
+function addIconSet(cesdk: CreativeEditorSDK) {
+  cesdk.ui.addIconSet(
+    '@imgly/plugin/background-removal',
+    `
+        <svg>
+          <symbol
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            id="@imgly/icons/BGRemove"
+          >
+          <path d="M5.5 3H7.59095L3 7.59095V5.5C3 4.11929 4.11929 3 5.5 3Z" fill="currentColor"/>
+<path d="M3 10.4093V13.5913L7.86161 8.72966C8.31641 7.66789 9.16789 6.81641 10.2297 6.36161L13.5913 3H10.4093L3 10.4093Z" fill="currentColor"/>
+<path d="M7.67225 11.737L3 16.4093V18.5C3 18.8239 3.06161 19.1335 3.17374 19.4175L6.14525 16.446L6.12969 16.2437C6.02445 14.8755 6.56566 13.3081 7.96581 12.4956C7.84616 12.2543 7.74749 12.0006 7.67225 11.737Z" fill="currentColor"/>
+<path d="M15.2273 7.36398C14.6868 6.80782 14.0037 6.39091 13.2371 6.17218L16.4093 3H18.5C18.8239 3 19.1335 3.06161 19.4175 3.17374L15.2273 7.36398Z" fill="currentColor"/>
+<path d="M6.34648 19.0623L4.58247 20.8263C4.86654 20.9384 5.17607 21 5.5 21H6.49553L6.34648 19.0623Z" fill="currentColor"/>
+<path d="M16.0725 12.5182C16.0598 12.5106 16.047 12.5031 16.0342 12.4956C16.3322 11.8946 16.5 11.2171 16.5 10.5C16.5 10.0198 16.4248 9.5572 16.2855 9.12328L20.8263 4.58253C20.9384 4.86658 21 5.1761 21 5.5V7.59079L16.0725 12.5182Z" fill="currentColor"/>
+<path d="M17.8305 16.7607L17.8703 16.2437C17.9278 15.4966 17.7925 14.69 17.4298 13.9795L21 10.4093V13.5913L17.8305 16.7607Z" fill="currentColor"/>
+<path d="M17.5045 21L17.5957 19.8136L21 16.4093V18.5C21 19.8807 19.8807 21 18.5 21H17.5045Z" fill="currentColor"/>
+<path d="M13.4317 13.1374C14.3663 12.6292 15.0007 11.6387 15.0007 10.5C15.0007 8.84315 13.6576 7.5 12.0007 7.5C10.3439 7.5 9.00074 8.84315 9.00074 10.5C9.00074 11.6387 9.63515 12.6292 10.5698 13.1374C9.94563 13.2733 9.38367 13.4801 8.9164 13.6917C7.98874 14.112 7.54792 15.1133 7.62602 16.1287L8.00074 21.0005H16.0007L16.3755 16.1287C16.4536 15.1133 16.0128 14.112 15.0851 13.6917C14.6178 13.4801 14.0559 13.2733 13.4317 13.1374Z" fill="currentColor"/>
+          </symbol>
+        </svg>
+      `
+  );
+}

--- a/packages/plugin-vectorizer-web/package.json
+++ b/packages/plugin-vectorizer-web/package.json
@@ -54,13 +54,14 @@
     "types:create": "tsc --emitDeclarationOnly"
   },
   "devDependencies": {
+    "@imgly/plugin-utils": "*",
+    "@types/lodash-es": "^4.17.12",
     "chalk": "^5.3.0",
     "concurrently": "^8.2.2",
     "esbuild": "^0.19.11",
     "eslint": "^8.51.0",
-    "typescript": "^5.3.3",
     "lodash-es": "^4.17.21",
-    "@imgly/plugin-utils": "*"
+    "typescript": "^5.3.3"
   },
   "peerDependencies": {
     "@cesdk/cesdk-js": "^1.32.0"

--- a/packages/plugin-vectorizer-web/src/plugin.ts
+++ b/packages/plugin-vectorizer-web/src/plugin.ts
@@ -6,7 +6,7 @@ import {
   type UserInterfaceConfiguration
 } from '@imgly/plugin-utils';
 
-import { EditorPlugin } from '@cesdk/cesdk-js';
+import CreativeEditorSDK, { EditorPlugin } from '@cesdk/cesdk-js';
 import { processVectorization } from './processVectorization';
 
 export const PLUGIN_ID = '@imgly/plugin-vectorizer-web';
@@ -37,6 +37,8 @@ export default (
     initialize({ cesdk }) {
       if (cesdk == null) return;
 
+      addIconSet(cesdk);
+
       initializeFillProcessing(cesdk, {
         pluginId: PLUGIN_ID,
         process: (blockId, metadata) => {
@@ -65,3 +67,25 @@ export default (
     }
   };
 };
+
+function addIconSet(cesdk: CreativeEditorSDK) {
+  cesdk.ui.addIconSet(
+    '@imgly/plugin/vectorizer',
+    `
+        <svg>
+          <symbol
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            id="@imgly/icons/Vectorize"
+          >
+          <rect x="11" y="2" width="2" height="20" fill="currentColor"/>
+          <path d="M13.6776 5.26764L19.9611 12L13.6776 18.7324L15.3224 20.2676L23.0389 12L15.3224 3.73242L13.6776 5.26764Z" fill="currentColor"/>
+          <path d="M4 10.5H1V13.5H4V16.5H7V19.5H10V16.5H7V13.5H4V10.5Z" fill="currentColor"/>
+          <path d="M4 10.5V7.50003H7V10.5H4Z" fill="currentColor"/>
+          <path d="M7 7.50003V4.50003H10V7.50003H7Z" fill="currentColor"/>
+          </symbol>
+        </svg>
+      `
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,17 +227,17 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@cesdk/cesdk-js@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@cesdk/cesdk-js/-/cesdk-js-1.39.0.tgz#84310a4d11c4901af540765e6d1938c203818e32"
-  integrity sha512-kW6FqmE5P3J09fxLH6MjIV2VKh8kFr6ATc5Q2LDGAH5+m6/WJoXwqdfPs8pQoFwGIPf5fkGlnstXLpbAGUjcJA==
+"@cesdk/cesdk-js@1.41.0":
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/@cesdk/cesdk-js/-/cesdk-js-1.41.0.tgz#1a863b48fbee4d19142e1ca283705128d3867f28"
+  integrity sha512-q4LYSI86NEPBrzQw2mvlvxq9u+FZ1oSGU65uQMKV4OQ37MBFVdNwdZUIcivl+i0SnRAOC+bGBFZ3MEiNjQskCQ==
   dependencies:
-    "@cesdk/engine" "1.39.0"
+    "@cesdk/engine" "1.41.0"
 
-"@cesdk/engine@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@cesdk/engine/-/engine-1.39.0.tgz#7b46ad7ced305f95daff792aca890e53fcb5c96b"
-  integrity sha512-rvEeQ/awyXXpIEMrHTHK/Wy3vh30BUA3WN4y00EYsTd6LwgZAeKa1YaviltYHlqKNXltgnocoVOopKFn9Mm5KQ==
+"@cesdk/engine@1.41.0":
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/@cesdk/engine/-/engine-1.41.0.tgz#3c88ea1aa030e78e5cba4f600d9e597b39cc6fda"
+  integrity sha512-FzZQXsDXkLtfh/gfMoOWx5EjNue0/aFUHW4/9SgClSEuYU0TRNP/eGYKol3HCI8I7MhLqBpl0ooum71ksrPWcA==
 
 "@esbuild/aix-ppc64@0.19.12":
   version "0.19.12"
@@ -642,6 +642,18 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
+"@types/lodash-es@^4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.13.tgz#786e2d67cfd95e32862143abe7463a7f90c300eb"
+  integrity sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==
 
 "@types/ndarray@^1.0.14":
   version "1.0.14"


### PR DESCRIPTION
The icons were removed from CE.SDK (1.40 onward). This change will add them to the plugin itself.