### PR TITLE
Add changes from asset library dock component in CE.SDK 1.51.1

### DIFF
--- a/packages/plugin-ai-apps-web/package.json
+++ b/packages/plugin-ai-apps-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-ai-apps-web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AI apps orchestration plugin for the CE.SDK editor",
   "keywords": ["CE.SDK", "plugin", "AI", "ai apps"],
   "repository": {

--- a/packages/plugin-ai-apps-web/src/plugin.ts
+++ b/packages/plugin-ai-apps-web/src/plugin.ts
@@ -399,11 +399,25 @@ function overrideAssetLibraryDockComponent(cesdk: CreativeEditorSDK) {
       const entryIds = payloadEntryIds.filter((entryId) => {
         const entry = cesdk.ui.getAssetLibraryEntry(entryId);
         if (entry == null) return false;
-
-        if (entry.sceneMode != null) {
-          return entry.sceneMode === sceneMode;
+        const entrySceneMode = entry.sceneMode;
+        if (typeof entrySceneMode === 'string') {
+          return (
+            entry.sceneMode === sceneMode ||
+            // Changes in the interface in CE.SDK version 1.51.0
+            // We do not want to bump the version for this change.
+            // @ts-ignore
+            entry.sceneMode === 'All'
+          );
         }
-
+        if (typeof entrySceneMode === 'function') {
+          return entry.sourceIds.some((sourceId) => {
+            // Changes in the interface in CE.SDK version 1.51.0
+            // We do not want to bump the version for this change.
+            // @ts-ignore
+            const sourceSceneMode = entrySceneMode(sourceId);
+            return sourceSceneMode === sceneMode || sourceSceneMode === 'All';
+          });
+        }
         return true;
       });
 

--- a/packages/plugin-ai-audio-generation-web/package.json
+++ b/packages/plugin-ai-audio-generation-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-ai-audio-generation-web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AI audio generation plugin for the CE.SDK editor",
   "keywords": ["CE.SDK", "plugin", "AI", "audio-generation"],
   "repository": {

--- a/packages/plugin-ai-generation-web/package.json
+++ b/packages/plugin-ai-generation-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-ai-generation-web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AI generation plugin for the CE.SDK editor",
   "keywords": ["CE.SDK", "plugin", "AI", "ai generation"],
   "repository": {

--- a/packages/plugin-ai-image-generation-web/package.json
+++ b/packages/plugin-ai-image-generation-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-ai-image-generation-web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AI image generation plugin for the CE.SDK editor",
   "keywords": [
     "CE.SDK",

--- a/packages/plugin-ai-text-generation-web/package.json
+++ b/packages/plugin-ai-text-generation-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-ai-text-generation-web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AI text generation plugin for the CE.SDK editor",
   "keywords": ["CE.SDK", "plugin", "AI", "text generation", "llm"],
   "repository": {

--- a/packages/plugin-ai-video-generation-web/package.json
+++ b/packages/plugin-ai-video-generation-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-ai-video-generation-web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AI video generation plugin for the CE.SDK editor",
   "keywords": ["CE.SDK", "plugin", "AI", "video-generation"],
   "repository": {


### PR DESCRIPTION
The default implementation for the component `ly.img.assetLibrary.dock` changed. Another check was added that allowed the entry to have a function and not only a string. The standard text entry is using a function now. With the old implementation, we compared the string with a function that was always `false`; thus, the text library dock component was never shown.

This change is released in 0.1.7 of the AI plugins.