### PR TITLE
Use Canvas Menu Order for Quick Action Order

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+-   [all] Quick action entries are now defined by `children` of a canvas menu component (set by `setCanvasMenuOrder`)
+-   [all] Prefix quick action IDs with provider model keys to prevent conflicts
+-   [all] All providers automatically add quick actions to the canvas menu (use `addQuickAction: false` to customize)
+-   [ai-generation] Add `enhanceProvider` helper function for automatic canvas menu integration
+
 ## [0.1.8] - 2025-05-26
 
 -   [ai-apps] Handle `sceneMode` change in upcoming CE.SDK version 1.52.0

--- a/examples/gpt-demo/src/index.ts
+++ b/examples/gpt-demo/src/index.ts
@@ -60,8 +60,38 @@ function initialize(
         ]);
 
         instance.ui.setCanvasMenuOrder([
-          'ly.img.ai.text.canvasMenu',
-          `ly.img.ai.image.canvasMenu`,
+          {
+            id: 'ly.img.ai.text.canvasMenu',
+            children: [
+              'improve',
+              'fix',
+              'shorter',
+              'longer',
+              'ly.img.separator',
+              'changeTone',
+              'translate',
+              'ly.img.separator',
+              'changeTextTo',
+              'ly.img.separator',
+              // Coming from GPT
+              'changeToImage'
+            ]
+          },
+          {
+            id: `ly.img.ai.image.canvasMenu`,
+
+            children: [
+              'changeStyleLibrary',
+              // 'changeStyle',
+              'ly.img.separator',
+              'swapBackground',
+              'changeImage',
+              'createVariant',
+              'combineImages',
+              'ly.img.separator',
+              'remixPage'
+            ]
+          },
           'ly.img.separator',
           ...instance.ui.getCanvasMenuOrder()
         ]);

--- a/examples/gpt-demo/src/index.ts
+++ b/examples/gpt-demo/src/index.ts
@@ -58,38 +58,8 @@ function initialize(
         ]);
 
         instance.ui.setCanvasMenuOrder([
-          {
-            id: 'ly.img.ai.text.canvasMenu',
-            children: [
-              'improve',
-              'fix',
-              'shorter',
-              'longer',
-              'ly.img.separator',
-              'changeTone',
-              'translate',
-              'ly.img.separator',
-              'changeTextTo',
-              'ly.img.separator',
-              // Coming from GPT
-              'changeToImage'
-            ]
-          },
-          {
-            id: `ly.img.ai.image.canvasMenu`,
-
-            children: [
-              'changeStyleLibrary',
-              // 'changeStyle',
-              'ly.img.separator',
-              'swapBackground',
-              'changeImage',
-              'createVariant',
-              'combineImages',
-              'ly.img.separator',
-              'remixPage'
-            ]
-          },
+          Anthropic.AnthropicProvider.canvasMenu.text,
+          OpenAiImage.GptImage1.Image2Image.canvasMenu.image,
           'ly.img.separator',
           ...instance.ui.getCanvasMenuOrder()
         ]);

--- a/examples/gpt-demo/src/index.ts
+++ b/examples/gpt-demo/src/index.ts
@@ -1,8 +1,6 @@
 import CreativeEditorSDK from '@cesdk/cesdk-js';
 import AiApps from '@imgly/plugin-ai-apps-web';
-// @ts-ignore
 import OpenAiImage from '@imgly/plugin-ai-image-generation-web/open-ai';
-// @ts-ignore
 import Anthropic from '@imgly/plugin-ai-text-generation-web/anthropic';
 
 import { rateLimitMiddleware } from '@imgly/plugin-ai-generation-web';

--- a/examples/gpt-demo/tsconfig.json
+++ b/examples/gpt-demo/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2017",
     "module": "es2020",
     "lib": ["es2018", "dom"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "isolatedModules": true,
     "esModuleInterop": true,
     "declaration": true,

--- a/examples/web/src/pages/ai-demo.tsx
+++ b/examples/web/src/pages/ai-demo.tsx
@@ -61,8 +61,36 @@ function App() {
             ]);
 
             instance.ui.setCanvasMenuOrder([
-              'ly.img.ai.text.canvasMenu',
-              `ly.img.ai.image.canvasMenu`,
+              {
+                id: 'ly.img.ai.text.canvasMenu',
+                children: [
+                  'improve',
+                  'fix',
+                  'shorter',
+                  'longer',
+                  'ly.img.separator',
+                  'changeTone',
+                  'translate',
+                  'ly.img.separator',
+                  'changeTextTo',
+                  'ly.img.separator',
+                  'changeToImage'
+                ]
+              },
+              {
+                id: `ly.img.ai.image.canvasMenu`,
+
+                children: [
+                  'styleTransfer',
+                  'artists',
+                  'ly.img.separator',
+                  'changeImage',
+                  'createVariant',
+                  'ly.img.separator',
+                  'createVideo'
+                ]
+              },
+
               ...instance.ui.getCanvasMenuOrder()
             ]);
 

--- a/examples/web/src/pages/ai-demo.tsx
+++ b/examples/web/src/pages/ai-demo.tsx
@@ -60,49 +60,15 @@ function App() {
               })
             ]);
 
-            instance.ui.setCanvasMenuOrder([
-              {
-                id: 'ly.img.ai.text.canvasMenu',
-                children: [
-                  'improve',
-                  'fix',
-                  'shorter',
-                  'longer',
-                  'ly.img.separator',
-                  'changeTone',
-                  'translate',
-                  'ly.img.separator',
-                  'changeTextTo',
-                  'ly.img.separator',
-                  'changeToImage'
-                ]
-              },
-              {
-                id: `ly.img.ai.image.canvasMenu`,
-
-                children: [
-                  'styleTransfer',
-                  'artists',
-                  'ly.img.separator',
-                  'changeImage',
-                  'createVariant',
-                  'ly.img.separator',
-                  'createVideo'
-                ]
-              },
-
-              ...instance.ui.getCanvasMenuOrder()
-            ]);
-
             instance.feature.enable('ly.img.preview', false);
             instance.feature.enable('ly.img.placeholder', false);
 
-            // await instance.engine.scene.loadFromArchiveURL(
-            //   `https://img.ly/showcases/cesdk/cases/ai-editor/ai_editor_video.archive`
-            // );
             await instance.engine.scene.loadFromArchiveURL(
-              `https://img.ly/showcases/cesdk/cases/ai-editor/ai_editor_design.archive`
+              `https://img.ly/showcases/cesdk/cases/ai-editor/ai_editor_video.archive`
             );
+            // await instance.engine.scene.loadFromArchiveURL(
+            //   `https://img.ly/showcases/cesdk/cases/ai-editor/ai_editor_design.archive`
+            // );
 
             const onRateLimitExceeded: RateLimitOptions<any>['onRateLimitExceeded'] =
               () => {
@@ -165,7 +131,7 @@ function App() {
 
             instance.addPlugin(
               AiApps({
-                debug: true,
+                debug: false,
                 dryRun: false,
                 providers: {
                   text2text: Anthropic.AnthropicProvider({

--- a/packages/plugin-ai-apps-web/README.md
+++ b/packages/plugin-ai-apps-web/README.md
@@ -77,6 +77,12 @@ CreativeEditorSDK.create(domElement, {
 
     // Position the AI dock button in the dock order
     cesdk.ui.setDockOrder(['ly.img.ai/apps.dock', ...cesdk.ui.getDockOrder()]);
+    
+    // Note: Canvas menu quick actions are automatically added by the providers
+    // You can access them via provider canvasMenu properties if needed:
+    // - AnthropicProvider.canvasMenu.text
+    // - FalAiImage.RecraftV3.canvasMenu.image
+    // - FalAiVideo.MinimaxVideo01LiveImageToVideo.canvasMenu.image
 });
 ```
 
@@ -133,6 +139,104 @@ The plugin automatically integrates generated assets into the appropriate asset 
 -   AI-generated audio appears in the standard audio library
 
 This integration creates a seamless experience where users can easily find and reuse their AI-generated assets.
+
+## Provider Quick Actions Reference
+
+Each AI provider automatically registers quick actions in canvas menus. Here's what gets added by each provider type:
+
+### Text Providers (Anthropic)
+
+**Canvas Menu:** `ly.img.ai.text.canvasMenu`
+
+- `anthropic.improve` - Improve writing quality
+- `anthropic.fix` - Fix spelling & grammar
+- `anthropic.shorter` / `anthropic.longer` - Adjust text length
+- `anthropic.changeTone` - Change writing tone
+- `anthropic.translate` - Translate to different languages
+- `anthropic.changeTextTo` - Custom text transformation
+
+### Image Providers (fal.ai/OpenAI)
+
+**Canvas Menu:** `ly.img.ai.image.canvasMenu`
+
+**GeminiFlashEdit (fal.ai):**
+- `fal-ai/gemini-flash-edit.changeImage` - Edit image with text prompt
+- `fal-ai/gemini-flash-edit.swapBackground` - Change image background
+- `fal-ai/gemini-flash-edit.styleTransfer` - Apply artistic styles
+- `fal-ai/gemini-flash-edit.createVariant` - Create image variants
+
+**OpenAI GPT-4:**
+- `open-ai/gpt-image-1/image2image.changeImage` - Edit image with text prompt
+- `open-ai/gpt-image-1/image2image.swapBackground` - Change image background
+- `open-ai/gpt-image-1/image2image.createVariant` - Create image variants
+
+### Video Providers (fal.ai)
+
+**Canvas Menu:** `ly.img.ai.image.canvasMenu` (appears in image context)
+
+**MinimaxVideo01LiveImageToVideo:**
+- `fal-ai/minimax/video-01-live/image-to-video.createVideo` - Convert image to video
+
+### Canvas Menu Control
+
+To disable automatic canvas menu registration and handle manually:
+
+```typescript
+AiApps({
+    providers: {
+        text2text: AnthropicProvider({
+            proxyUrl: 'https://your-anthropic-proxy.example.com',
+            addToCanvasMenu: false // Disable automatic registration
+        }),
+        // ... other providers
+    }
+})
+
+// Manually configure canvas menu
+cesdk.ui.setCanvasMenuOrder([
+    {
+        id: AnthropicProvider.canvasMenu.text.id,
+        children: AnthropicProvider.canvasMenu.text.children
+    },
+    {
+        id: FalAiImage.GeminiFlashEdit.canvasMenu.image.id,
+        children: FalAiImage.GeminiFlashEdit.canvasMenu.image.children
+    },
+    ...cesdk.ui.getCanvasMenuOrder()
+]);
+```
+
+### Customizing Quick Action Order
+
+To customize quick action ordering or remove specific actions, disable automatic registration and configure manually:
+
+```typescript
+// Example: Customize text quick actions - remove some actions and reorder
+cesdk.ui.setCanvasMenuOrder([
+    {
+        id: 'ly.img.ai.text.canvasMenu',
+        children: [
+            'anthropic.improve',      // Keep most commonly used first
+            'anthropic.fix',
+            'ly.img.separator',
+            'anthropic.translate',    // Moved up in priority
+            'anthropic.changeTextTo'  // Keep custom transformation
+            // Removed: shorter, longer, changeTone for simplified menu
+        ]
+    },
+    {
+        id: 'ly.img.ai.image.canvasMenu', 
+        children: [
+            'fal-ai/gemini-flash-edit.changeImage',     // Most used first
+            'fal-ai/gemini-flash-edit.swapBackground',
+            'ly.img.separator',
+            'fal-ai/gemini-flash-edit.createVariant'    // Keep variant creation
+            // Removed: styleTransfer, artistStyles for focused menu
+        ]
+    },
+    ...cesdk.ui.getCanvasMenuOrder()
+]);
+```
 
 ## Related Packages
 

--- a/packages/plugin-ai-apps-web/TUTORIAL.md
+++ b/packages/plugin-ai-apps-web/TUTORIAL.md
@@ -81,12 +81,11 @@ function App() {
                             ...instance.ui.getDockOrder()
                         ]);
 
-                        // Add AI options to canvas menu
-                        instance.ui.setCanvasMenuOrder([
-                            'ly.img.ai.text.canvasMenu',
-                            'ly.img.ai.image.canvasMenu',
-                            ...instance.ui.getCanvasMenuOrder()
-                        ]);
+                        // Note: Canvas menu quick actions are automatically added by the providers
+                        // You can access them via provider canvasMenu properties if needed:
+                        // - AnthropicProvider.canvasMenu.text.id
+                        // - FalAiImage.RecraftV3.canvasMenu.image.id
+                        // - FalAiVideo.MinimaxVideo01LiveImageToVideo.canvasMenu.image.id
 
                         // Add the AI Apps plugin with all providers
                         instance.addPlugin(
@@ -275,12 +274,114 @@ cesdk.ui.setDockOrder(currentOrder);
 
 ### Canvas Menu Options
 
-AI text and image transformations are available in the canvas context menu:
+AI text and image transformations are automatically added to the canvas context menu by the enhanced providers. You can access canvas menu component IDs from the providers:
 
 ```typescript
+// Canvas menu components are automatically registered
+// Access them via enhanced provider properties:
+const textCanvasMenu = AnthropicProvider.canvasMenu.text.id; // 'ly.img.ai.text.canvasMenu'
+const imageCanvasMenu = FalAiImage.RecraftV3.canvasMenu.image.id; // 'ly.img.ai.image.canvasMenu'
+
+// Manual ordering (if needed):
 cesdk.ui.setCanvasMenuOrder([
-    'ly.img.ai.text.canvasMenu',
-    'ly.img.ai.image.canvasMenu',
+    AnthropicProvider.canvasMenu.text.id,
+    FalAiImage.RecraftV3.canvasMenu.image.id,
+    ...cesdk.ui.getCanvasMenuOrder()
+]);
+```
+
+### Customizing Quick Actions
+
+If you need to customize which quick actions appear or their order, you can disable automatic canvas menu registration and configure manually:
+
+#### Disabling Automatic Registration
+
+```typescript
+// Configure providers without automatic canvas menu registration
+instance.addPlugin(
+    AiApps({
+        providers: {
+            text2text: AnthropicProvider({
+                proxyUrl: 'https://your-server.com/api/anthropic-proxy',
+                addToCanvasMenu: false // Disable automatic registration
+            }),
+            text2image: FalAiImage.RecraftV3({
+                proxyUrl: 'https://your-server.com/api/fal-ai-proxy',
+                addToCanvasMenu: false
+            }),
+            image2image: FalAiImage.GeminiFlashEdit({
+                proxyUrl: 'https://your-server.com/api/fal-ai-proxy',
+                addToCanvasMenu: false
+            })
+        }
+    })
+);
+```
+
+#### Manual Canvas Menu Configuration
+
+```typescript
+// Manually configure canvas menu with custom quick action selection and order
+instance.ui.setCanvasMenuOrder([
+    {
+        id: 'ly.img.ai.text.canvasMenu',
+        children: [
+            'anthropic.improve',      // Most commonly used
+            'anthropic.fix',
+            'ly.img.separator',
+            'anthropic.translate',    // Prioritized for international users
+            'anthropic.changeTextTo'  // Custom transformations
+            // Removed: shorter, longer, changeTone for simplified menu
+        ]
+    },
+    {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: [
+            'fal-ai/gemini-flash-edit.changeImage',     // Primary image editing
+            'fal-ai/gemini-flash-edit.swapBackground',  // Popular feature
+            'ly.img.separator',
+            'fal-ai/gemini-flash-edit.createVariant',   // Creative options
+            'fal-ai/minimax/video-01-live/image-to-video.createVideo' // Video creation
+            // Removed: styleTransfer, artistStyles for focused experience
+        ]
+    },
+    ...instance.ui.getCanvasMenuOrder()
+]);
+```
+
+#### Quick Action Customization Strategies
+
+**For Simplified User Experience:**
+- Remove advanced features like style transfer and tone changing
+- Keep only the most commonly used actions
+- Focus on core editing capabilities
+
+**For Power Users:**
+- Include all available quick actions
+- Organize by frequency of use
+- Group related actions with separators
+
+**For Specific Use Cases:**
+- **Content Creation**: Prioritize `improve`, `changeTextTo`, `createVariant`
+- **International Apps**: Prioritize `translate`, `changeTone`
+- **Quick Edits**: Focus on `fix`, `changeImage`, `swapBackground`
+
+#### Accessing Provider Quick Action Lists
+
+```typescript
+// Get the full list of available quick actions from each provider
+const textQuickActions = AnthropicProvider.canvasMenu.text.children;
+// ['anthropic.improve', 'anthropic.fix', 'anthropic.shorter', ...]
+
+const imageQuickActions = FalAiImage.GeminiFlashEdit.canvasMenu.image.children;
+// ['fal-ai/gemini-flash-edit.changeImage', 'fal-ai/gemini-flash-edit.swapBackground', ...]
+
+// Use these arrays as a base for your custom configuration
+cesdk.ui.setCanvasMenuOrder([
+    {
+        id: 'ly.img.ai.text.canvasMenu',
+        children: textQuickActions.slice(0, 4) // Take only first 4 actions
+    },
     ...cesdk.ui.getCanvasMenuOrder()
 ]);
 ```
@@ -443,6 +544,16 @@ When implementing your proxy:
 - Implement proper error handling without leaking sensitive information
 
 This approach ensures your API keys remain secure while still allowing your application to utilize AI services. For a complete example of a proxy implementation, you can find various proxy templates online that can be adapted for your specific needs.
+
+## Quick Actions Reference
+
+For a complete reference of all available quick actions and their IDs, see the individual plugin documentation:
+
+- **Text Quick Actions** (Anthropic): `anthropic.improve`, `anthropic.fix`, `anthropic.shorter`, `anthropic.longer`, `anthropic.changeTone`, `anthropic.translate`, `anthropic.changeTextTo`
+- **Image Quick Actions** (GeminiFlashEdit): `fal-ai/gemini-flash-edit.changeImage`, `fal-ai/gemini-flash-edit.swapBackground`, `fal-ai/gemini-flash-edit.styleTransfer`, `fal-ai/gemini-flash-edit.artistStyles`, `fal-ai/gemini-flash-edit.createVariant`
+- **Video Quick Actions**: `fal-ai/minimax/video-01-live/image-to-video.createVideo`
+
+Each quick action ID follows the pattern `{provider-model-key}.{action-name}` to ensure uniqueness across providers.
 
 ## Conclusion
 

--- a/packages/plugin-ai-apps-web/src/plugin.ts
+++ b/packages/plugin-ai-apps-web/src/plugin.ts
@@ -6,7 +6,8 @@ import {
   Middleware,
   OutputKind,
   getPanelId,
-  Output
+  Output,
+  GetProvider
 } from '@imgly/plugin-ai-generation-web';
 
 import ImageGeneration from '@imgly/plugin-ai-image-generation-web';
@@ -17,7 +18,7 @@ import { AggregatedAssetSource } from '@imgly/plugin-utils';
 import CustomAssetSource, {
   createCustomAssetSource
 } from './ActiveAssetSource';
-import { GetProvider, PluginConfiguration, Providers } from './types';
+import { PluginConfiguration, Providers } from './types';
 
 export { PLUGIN_ID } from './constants';
 

--- a/packages/plugin-ai-apps-web/src/types.ts
+++ b/packages/plugin-ai-apps-web/src/types.ts
@@ -1,11 +1,4 @@
-import CreativeEditorSDK from '@cesdk/cesdk-js';
-import { Provider, OutputKind } from '@imgly/plugin-ai-generation-web';
-
-export type GetProvider<K extends OutputKind> = ({
-  cesdk
-}: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<K, any, any>>;
+import { GetProvider } from '@imgly/plugin-ai-generation-web';
 
 /**
  * The provider configuration that maps capabilities

--- a/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenMultilingualV2.ts
+++ b/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenMultilingualV2.ts
@@ -1,7 +1,8 @@
 import {
   type Provider,
   type AudioOutput,
-  Middleware
+  Middleware,
+  enhanceProvider
 } from '@imgly/plugin-ai-generation-web';
 import CreativeEditorSDK from '@cesdk/cesdk-js';
 import schema from './ElevenMultilingualV2.json';
@@ -33,15 +34,7 @@ type ProviderConfiguration = {
   baseURL?: string;
 };
 
-export function ElevenMultilingualV2(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'audio', ElevenlabsInput, AudioOutput>> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const ElevenMultilingualV2 = enhanceProvider(getProvider);
 
 function getProvider(
   cesdk: CreativeEditorSDK,

--- a/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenSoundEffects.ts
+++ b/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenSoundEffects.ts
@@ -1,7 +1,8 @@
 import {
   type Provider,
   type AudioOutput,
-  Middleware
+  Middleware,
+  enhanceProvider
 } from '@imgly/plugin-ai-generation-web';
 import CreativeEditorSDK from '@cesdk/cesdk-js';
 import schema from './ElevenSoundEffects.json';
@@ -18,15 +19,7 @@ type ProviderConfiguration = {
   middleware?: Middleware<ElevenlabsInput, AudioOutput>[];
 };
 
-export function ElevenSoundEffects(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'audio', ElevenlabsInput, AudioOutput>> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const ElevenSoundEffects = enhanceProvider(getProvider);
 
 function getProvider(
   cesdk: CreativeEditorSDK,

--- a/packages/plugin-ai-audio-generation-web/src/plugin.ts
+++ b/packages/plugin-ai-audio-generation-web/src/plugin.ts
@@ -1,9 +1,5 @@
-import CreativeEditorSDK from '@cesdk/cesdk-js';
 import { NotificationDuration, type EditorPlugin } from '@cesdk/cesdk-js';
-import {
-  initProvider,
-  getQuickActionMenu
-} from '@imgly/plugin-ai-generation-web';
+import { initProvider } from '@imgly/plugin-ai-generation-web';
 import { PluginConfiguration } from './types';
 
 export { PLUGIN_ID } from './constants';
@@ -111,13 +107,6 @@ export function AudioGeneration(
       }
 
       if (text2speechInitialized?.renderBuilderFunctions?.panel != null) {
-        addQuickActionEntryForText2Speech(cesdk, (text) => {
-          cesdk.ui.openPanel(SPEECH_GENERATION_PANEL_ID);
-          cesdk.ui.experimental.setGlobalStateValue(
-            `${text2speech?.id}.prompt`,
-            text
-          );
-        });
         cesdk.ui.registerPanel(
           SPEECH_GENERATION_PANEL_ID,
           text2speechInitialized.renderBuilderFunctions.panel
@@ -125,52 +114,6 @@ export function AudioGeneration(
       }
     }
   };
-}
-
-function addQuickActionEntryForText2Speech(
-  cesdk: CreativeEditorSDK,
-  onClick: (text: string) => void
-) {
-  const quickActionMenu = getQuickActionMenu(cesdk, 'text');
-  const generateSpeechId = 'generateSpeech';
-  quickActionMenu.registerQuickAction({
-    id: generateSpeechId,
-    version: '1',
-    confirmation: false,
-    enable: ({ engine }) => {
-      const blockIds = engine.block.findAllSelected();
-      if (blockIds.length !== 1) {
-        return false;
-      }
-
-      const [blockId] = blockIds;
-      if (engine.block.getType(blockId) !== '//ly.img.ubq/text') {
-        return false;
-      }
-
-      return true;
-    },
-    render: ({ builder }, context) => {
-      builder.Button(generateSpeechId, {
-        icon: '@imgly/Audio',
-        variant: 'plain',
-        labelAlignment: 'left',
-        label: 'AI Voice...',
-        onClick: () => {
-          const [blockId] = cesdk.engine.block.findAllSelected();
-          const text = cesdk.engine.block.getString(blockId, 'text/text');
-          onClick(text);
-          context.closeMenu();
-        }
-      });
-    }
-  });
-
-  quickActionMenu.setQuickActionMenuOrder([
-    ...quickActionMenu.getQuickActionMenuOrder(),
-    'ly.img.separator',
-    generateSpeechId
-  ]);
 }
 
 export default AudioGeneration;

--- a/packages/plugin-ai-generation-web/src/__tests__/addToCanvasMenu.test.ts
+++ b/packages/plugin-ai-generation-web/src/__tests__/addToCanvasMenu.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import CreativeEditorSDK from '@cesdk/cesdk-js';
+import addToCanvasMenu from '../generation/addToCanvasMenu';
+import { QuickActionCanvasMenuComponents } from '../generation/quickAction/types';
+
+describe('addToCanvasMenu', () => {
+  let mockCesdk: jest.Mocked<CreativeEditorSDK>;
+
+  beforeEach(() => {
+    mockCesdk = {
+      ui: {
+        getCanvasMenuOrder: jest.fn(),
+        setCanvasMenuOrder: jest.fn()
+      }
+    } as any;
+  });
+
+  it('should add new components to the beginning of canvas menu', () => {
+    const existingOrder = [{ id: 'existing.component', label: 'Existing' }];
+    const components: QuickActionCanvasMenuComponents = {
+      image: {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['image.child1', 'image.child2']
+      },
+      text: {
+        id: 'ly.img.ai.text.canvasMenu',
+        children: ['text.child1']
+      }
+    };
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue(existingOrder);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith([
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['image.child1', 'image.child2']
+      },
+      {
+        id: 'ly.img.ai.text.canvasMenu',
+        children: ['text.child1']
+      },
+      { id: 'existing.component', label: 'Existing' }
+    ]);
+  });
+
+  it('should update existing component children instead of adding duplicate', () => {
+    const existingOrder = [
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['existing.child1', 'existing.child2']
+      },
+      { id: 'other.component', label: 'Other' }
+    ];
+    const components: QuickActionCanvasMenuComponents = {
+      image: {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['new.child1', 'new.child2']
+      }
+    };
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue(existingOrder);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith([
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: [
+          'existing.child1',
+          'existing.child2',
+          'new.child1',
+          'new.child2'
+        ]
+      },
+      { id: 'other.component', label: 'Other' }
+    ]);
+  });
+
+  it('should not add duplicate children when they already exist', () => {
+    const existingOrder = [
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['existing.child1', 'existing.child2']
+      },
+      { id: 'other.component', label: 'Other' }
+    ];
+    const components: QuickActionCanvasMenuComponents = {
+      image: {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['existing.child1', 'new.child1']
+      }
+    };
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue(existingOrder);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith([
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['existing.child1', 'existing.child2', 'new.child1']
+      },
+      { id: 'other.component', label: 'Other' }
+    ]);
+  });
+
+  it('should handle empty components object', () => {
+    const existingOrder = [{ id: 'existing.component', label: 'Existing' }];
+    const components: QuickActionCanvasMenuComponents = {};
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue(existingOrder);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith(existingOrder);
+  });
+
+  it('should handle empty existing canvas menu', () => {
+    const components: QuickActionCanvasMenuComponents = {
+      image: {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['image.child1']
+      }
+    };
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue([]);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith([
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['image.child1']
+      }
+    ]);
+  });
+
+  it('should add children property when component has no children', () => {
+    const existingOrder = [
+      { id: 'ly.img.ai.image.canvasMenu', label: 'Image AI' },
+      { id: 'other.component', label: 'Other' }
+    ];
+    const components: QuickActionCanvasMenuComponents = {
+      image: {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['new.child1']
+      }
+    };
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue(existingOrder);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith([
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        label: 'Image AI',
+        children: ['new.child1']
+      },
+      { id: 'other.component', label: 'Other' }
+    ]);
+  });
+
+  it('should replace non-array children with array children', () => {
+    const existingOrder = [
+      { id: 'ly.img.ai.image.canvasMenu', children: 'not-an-array' },
+      { id: 'other.component', label: 'Other' }
+    ];
+    const components: QuickActionCanvasMenuComponents = {
+      image: {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['new.child1']
+      }
+    };
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue(existingOrder);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith([
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['new.child1']
+      },
+      { id: 'other.component', label: 'Other' }
+    ]);
+  });
+
+  it('should preserve existing separators in children arrays and not duplicate them', () => {
+    const existingOrder = [
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['existing.child1', 'ly.img.separator', 'existing.child2']
+      },
+      { id: 'other.component', label: 'Other' }
+    ];
+    const components: QuickActionCanvasMenuComponents = {
+      image: {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: ['new.child1', 'ly.img.separator']
+      }
+    };
+
+    mockCesdk.ui.getCanvasMenuOrder.mockReturnValue(existingOrder);
+
+    addToCanvasMenu(mockCesdk, components);
+
+    expect(mockCesdk.ui.setCanvasMenuOrder).toHaveBeenCalledWith([
+      {
+        id: 'ly.img.ai.image.canvasMenu',
+        children: [
+          'existing.child1',
+          'ly.img.separator',
+          'existing.child2',
+          'new.child1',
+          'ly.img.separator'
+        ]
+      },
+      { id: 'other.component', label: 'Other' }
+    ]);
+  });
+});

--- a/packages/plugin-ai-generation-web/src/generation/addToCanvasMenu.ts
+++ b/packages/plugin-ai-generation-web/src/generation/addToCanvasMenu.ts
@@ -1,0 +1,40 @@
+import CreativeEditorSDK from '@cesdk/cesdk-js';
+import { QuickActionCanvasMenuComponents } from './quickAction/types';
+
+function addToCanvasMenu(
+  cesdk: CreativeEditorSDK,
+  components: QuickActionCanvasMenuComponents
+): void {
+  const currentCanvasMenuOrder = cesdk.ui.getCanvasMenuOrder();
+  const componentsArray = Object.values(components).filter((component) => {
+    // Is this component already in the canvas menu? In that case update the order.
+    // Allow ly.img.separator to be added multiple times by never finding existing ones
+    const currentCanvasMenuCompnent = currentCanvasMenuOrder.find((item) => {
+      return item.id === component.id;
+    });
+    if (currentCanvasMenuCompnent != null) {
+      if (
+        'children' in currentCanvasMenuCompnent &&
+        Array.isArray(currentCanvasMenuCompnent.children)
+      ) {
+        const existingChildren = currentCanvasMenuCompnent.children as string[];
+        const newChildren = component.children.filter(
+          (childId) =>
+            !existingChildren.includes(childId) ||
+            childId === 'ly.img.separator'
+        );
+        currentCanvasMenuCompnent.children = [
+          ...existingChildren,
+          ...newChildren
+        ];
+      } else {
+        currentCanvasMenuCompnent.children = component.children;
+      }
+      return false;
+    }
+    return true;
+  });
+  cesdk.ui.setCanvasMenuOrder([...componentsArray, ...currentCanvasMenuOrder]);
+}
+
+export default addToCanvasMenu;

--- a/packages/plugin-ai-generation-web/src/generation/enhanceProvider.ts
+++ b/packages/plugin-ai-generation-web/src/generation/enhanceProvider.ts
@@ -1,0 +1,39 @@
+import CreativeEditorSDK from '@cesdk/cesdk-js';
+import Provider, { Output, OutputKind } from './provider';
+import { GetProvider } from './types';
+import { QuickActionCanvasMenuComponents } from './quickAction/types';
+
+/**
+ * Enhances "to-be-configured" GetProvider by adding additional configuration
+ * options that can be easily accessed by the integrator.
+ *
+ * This should be called right before you export your provider.
+ *
+ * @param getProvider - A function that returns a provider based on the CESDK instance and configuration.
+ * @param options - Additional options to enhance the provider
+ * @param options.canvasMenuComponents - Components to be used in the canvas menu order.
+ */
+function enhanceProvider<C, K extends OutputKind, I, O extends Output>(
+  getProvider: (
+    cesdk: CreativeEditorSDK,
+    config: C
+  ) => Promise<Provider<K, I, O>> | Provider<K, I, O>,
+  options: {
+    canvasMenu?: QuickActionCanvasMenuComponents;
+  } = {
+    canvasMenu: {}
+  }
+): ((config: C) => GetProvider<K, I, O>) & {
+  canvasMenu: QuickActionCanvasMenuComponents;
+} {
+  const configureGetProvider = (config: C): GetProvider<K, I, O> => {
+    return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
+      return getProvider(cesdk, config);
+    };
+  };
+  return Object.assign(configureGetProvider, {
+    canvasMenu: options.canvasMenu || {}
+  });
+}
+
+export default enhanceProvider;

--- a/packages/plugin-ai-generation-web/src/generation/handleGenerationError.ts
+++ b/packages/plugin-ai-generation-web/src/generation/handleGenerationError.ts
@@ -3,6 +3,29 @@ import Provider, { GetInput, Output, OutputKind } from './provider';
 import { InitProviderConfiguration } from './types';
 import { extractErrorMessage } from '../utils';
 
+export function createHandleGenerationError<
+  K extends OutputKind,
+  I,
+  O extends Output
+>(
+  boundOptions: {
+    cesdk: CreativeEditorSDK;
+    provider: Provider<K, I, O>;
+  },
+  config: InitProviderConfiguration
+) {
+  return (error: unknown, options?: { getInput?: GetInput<I> }) => {
+    handleGenerationError<K, I, O>(
+      error,
+      {
+        ...boundOptions,
+        ...options
+      },
+      config
+    );
+  };
+}
+
 function handleGenerationError<K extends OutputKind, I, O extends Output>(
   error: unknown,
   options: {

--- a/packages/plugin-ai-generation-web/src/generation/initProvider.ts
+++ b/packages/plugin-ai-generation-web/src/generation/initProvider.ts
@@ -11,7 +11,7 @@ import { InitProviderConfiguration, Options, UIOptions } from './types';
 import { BuilderRenderFunction, type CreativeEngine } from '@cesdk/cesdk-js';
 import { IndexedDBAssetSource } from '@imgly/plugin-utils';
 import icons from '../icons';
-import getQuickActionMenu from './quickAction/getQuickActionMenu';
+import getQuickActionRegistry from './quickAction/getQuickActionRegistry';
 import { getFeatureIdForQuickAction } from './quickAction/utils';
 import registerQuickActionMenuComponent from './quickAction/registerQuickActionMenuComponent';
 import { QuickActionMenu } from './quickAction/types';
@@ -221,7 +221,7 @@ async function initQuickActions<K extends OutputKind, I, O extends Output>(
   quickActionsInput.actions.forEach((quickAction) => {
     const quickActionMenuId = quickAction.kind ?? provider.kind;
     if (quickActionMenus[quickActionMenuId] == null) {
-      quickActionMenus[quickActionMenuId] = getQuickActionMenu(
+      quickActionMenus[quickActionMenuId] = getQuickActionRegistry(
         cesdk,
         quickActionMenuId
       );

--- a/packages/plugin-ai-generation-web/src/generation/initProvider.ts
+++ b/packages/plugin-ai-generation-web/src/generation/initProvider.ts
@@ -15,6 +15,8 @@ import getQuickActionMenu from './quickAction/getQuickActionMenu';
 import { getFeatureIdForQuickAction } from './quickAction/utils';
 import registerQuickActionMenuComponent from './quickAction/registerQuickActionMenuComponent';
 import { QuickActionMenu } from './quickAction/types';
+import createGenerateFunction from './quickAction/generate';
+import { createHandleGenerationError } from './handleGenerationError';
 
 type RenderBuilderFunctions = {
   panel?: BuilderRenderFunction<any>;
@@ -234,7 +236,30 @@ async function initQuickActions<K extends OutputKind, I, O extends Output>(
       }),
       enable
     );
-    quickActionMenu.registerQuickAction(quickAction);
+
+    const boundGenerate = createGenerateFunction(
+      {
+        cesdk,
+        provider,
+        quickAction
+      },
+      config
+    );
+
+    const boundErrorHandler = createHandleGenerationError<K, I, O>(
+      {
+        cesdk,
+        provider
+      },
+      config
+    );
+
+    quickActionMenu.registerQuickAction({
+      ...quickAction,
+      generate: boundGenerate,
+      onError: boundErrorHandler
+    });
+
     if (config.debug) {
       // eslint-disable-next-line no-console
       console.log(
@@ -244,14 +269,10 @@ async function initQuickActions<K extends OutputKind, I, O extends Output>(
   });
 
   Object.values(quickActionMenus).forEach((quickActionMenu) => {
-    const { canvasMenuComponentId } = registerQuickActionMenuComponent(
-      {
-        cesdk,
-        quickActionMenu,
-        provider
-      },
-      config
-    );
+    const { canvasMenuComponentId } = registerQuickActionMenuComponent({
+      cesdk,
+      quickActionMenu
+    });
     if (config.debug) {
       // eslint-disable-next-line no-console
       console.log(

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/generate.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/generate.ts
@@ -1,5 +1,9 @@
 import CreativeEditorSDK from '@cesdk/cesdk-js';
-import { InferenceMetadata, ApplyCallbacks } from './types';
+import {
+  InferenceMetadata,
+  ApplyCallbacks,
+  QuickActionGenerateFunction
+} from './types';
 import { INFERENCE_AI_EDIT_MODE, INFERENCE_AI_METADATA_KEY } from './utils';
 import { Metadata } from '@imgly/plugin-utils';
 import Provider, {
@@ -17,6 +21,24 @@ import consumeGeneratedResult from './consumeGeneratedResult';
 import editModeMiddleware from '../middleware/editModeMiddleware';
 import { InitProviderConfiguration } from '../types';
 import dryRunMiddleware from '../middleware/dryRunMiddleware';
+
+function createGenerateFunction<K extends OutputKind, I, O extends Output>(
+  boundOptions: {
+    cesdk: CreativeEditorSDK;
+    provider: Provider<K, I, O>;
+    quickAction: QuickAction<I, O>;
+  },
+  config: InitProviderConfiguration
+): QuickActionGenerateFunction<I, O> {
+  return async (options: {
+    input: I;
+    blockIds: number[];
+    abortSignal: AbortSignal;
+    confirmationComponentId: string;
+  }) => {
+    return generate<K, I, O>({ ...options, ...boundOptions }, config);
+  };
+}
 
 async function generate<K extends OutputKind, I, O extends Output>(
   options: {
@@ -131,4 +153,4 @@ async function generate<K extends OutputKind, I, O extends Output>(
   };
 }
 
-export default generate;
+export default createGenerateFunction;

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/generate.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/generate.ts
@@ -1,5 +1,5 @@
 import CreativeEditorSDK from '@cesdk/cesdk-js';
-import { InferenceMetadata, QuickActionMenu, ApplyCallbacks } from './types';
+import { InferenceMetadata, ApplyCallbacks } from './types';
 import { INFERENCE_AI_EDIT_MODE, INFERENCE_AI_METADATA_KEY } from './utils';
 import { Metadata } from '@imgly/plugin-utils';
 import Provider, {
@@ -24,7 +24,6 @@ async function generate<K extends OutputKind, I, O extends Output>(
     blockIds: number[];
     cesdk: CreativeEditorSDK;
     quickAction: QuickAction<I, O>;
-    quickActionMenu: QuickActionMenu;
     provider: Provider<K, I, O>;
     abortSignal: AbortSignal;
     confirmationComponentId: string;

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/getQuickActionMenu.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/getQuickActionMenu.ts
@@ -1,6 +1,6 @@
 import CreativeEditorSDK from '@cesdk/cesdk-js';
-import { QuickActionId, QuickActionMenu } from './types';
-import { Output, QuickAction } from '../provider';
+import { QuickActionId, QuickActionMenu, RegisteredQuickAction } from './types';
+import { type Output, type QuickAction } from '../provider';
 
 const QUICK_ACTION_ORDER_KEY_PREFIX = 'ly.img.ai.quickAction.order';
 
@@ -28,7 +28,7 @@ function getQuickActionMenu(cesdk: CreativeEditorSDK, id: string) {
       );
     },
     registerQuickAction: <I, O extends Output>(
-      quickAction: QuickAction<I, O>
+      quickAction: RegisteredQuickAction<I, O>
     ) => {
       if (
         !cesdk.ui.experimental.hasGlobalStateValue(
@@ -57,7 +57,7 @@ function getQuickActionMenu(cesdk: CreativeEditorSDK, id: string) {
 
     getQuickAction: <I, O extends Output>(quickActionId: string) => {
       const entries = cesdk.ui.experimental.getGlobalStateValue<{
-        [key: string]: QuickAction<I, O>;
+        [key: string]: RegisteredQuickAction<I, O>;
       }>(`${QUICK_ACTION_REGISTRY_PREFIX}.${id}`, {});
 
       return entries[quickActionId];

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/getQuickActionMenu.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/getQuickActionMenu.ts
@@ -1,8 +1,6 @@
 import CreativeEditorSDK from '@cesdk/cesdk-js';
-import { QuickActionId, QuickActionMenu, RegisteredQuickAction } from './types';
+import { QuickActionMenu, RegisteredQuickAction } from './types';
 import { type Output, type QuickAction } from '../provider';
-
-const QUICK_ACTION_ORDER_KEY_PREFIX = 'ly.img.ai.quickAction.order';
 
 const QUICK_ACTION_REGISTRY_PREFIX = 'ly.img.ai.quickAction.actions';
 
@@ -15,18 +13,6 @@ const QUICK_ACTION_REGISTRY_PREFIX = 'ly.img.ai.quickAction.actions';
 function getQuickActionMenu(cesdk: CreativeEditorSDK, id: string) {
   const quickActionMenu: QuickActionMenu = {
     id,
-    setQuickActionMenuOrder: (quickActionIds: string[]) => {
-      cesdk.ui.experimental.setGlobalStateValue<QuickActionId[]>(
-        `${QUICK_ACTION_ORDER_KEY_PREFIX}.${id}`,
-        quickActionIds
-      );
-    },
-    getQuickActionMenuOrder: () => {
-      return cesdk.ui.experimental.getGlobalStateValue<QuickActionId[]>(
-        `${QUICK_ACTION_ORDER_KEY_PREFIX}.${id}`,
-        []
-      );
-    },
     registerQuickAction: <I, O extends Output>(
       quickAction: RegisteredQuickAction<I, O>
     ) => {

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/getQuickActionRegistry.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/getQuickActionRegistry.ts
@@ -5,12 +5,12 @@ import { type Output, type QuickAction } from '../provider';
 const QUICK_ACTION_REGISTRY_PREFIX = 'ly.img.ai.quickAction.actions';
 
 /**
- * Returns an object representing the quick action menu. Can be called and
+ * Returns an object representing the quick action registry. Can be called and
  * retrieved multiple times.
  *
  * It's backed up by the global state.
  */
-function getQuickActionMenu(cesdk: CreativeEditorSDK, id: string) {
+function getQuickActionRegistry(cesdk: CreativeEditorSDK, id: string) {
   const quickActionMenu: QuickActionMenu = {
     id,
     registerQuickAction: <I, O extends Output>(
@@ -52,4 +52,4 @@ function getQuickActionMenu(cesdk: CreativeEditorSDK, id: string) {
   return quickActionMenu;
 }
 
-export default getQuickActionMenu;
+export default getQuickActionRegistry;

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/registerQuickActionMenuComponent.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/registerQuickActionMenuComponent.ts
@@ -269,7 +269,6 @@ function registerQuickActionMenuComponent<
                           {
                             input,
                             quickAction,
-                            quickActionMenu,
                             provider,
                             cesdk,
                             abortSignal: createAbortSignal(),
@@ -334,7 +333,6 @@ function registerQuickActionMenuComponent<
                               {
                                 input,
                                 quickAction,
-                                quickActionMenu,
                                 provider,
                                 cesdk,
                                 abortSignal: createAbortSignal(),

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/types.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/types.ts
@@ -1,5 +1,5 @@
 import { createHandleGenerationError } from '../handleGenerationError';
-import { type Output, type QuickAction } from '../provider';
+import { type OutputKind, type Output, type QuickAction } from '../provider';
 
 export type QuickActionId = 'ly.img.separator' | (string & {});
 
@@ -36,6 +36,13 @@ export interface RegisteredQuickAction<I, O extends Output>
   generate: QuickActionGenerateFunction<I, O>;
   onError: ReturnType<typeof createHandleGenerationError<any, I, O>>;
 }
+
+export type QuickActionCanvasMenuComponents = {
+  [K in OutputKind]?: {
+    id: `ly.img.ai.${K}.canvasMenu`;
+    children: string[];
+  };
+};
 
 export type InferenceStatus = 'processing' | 'confirmation';
 

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/types.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/types.ts
@@ -1,4 +1,5 @@
-import { Output, type QuickAction } from '../provider';
+import { createHandleGenerationError } from '../handleGenerationError';
+import { type Output, type QuickAction } from '../provider';
 
 export type QuickActionId = 'ly.img.separator' | (string & {});
 
@@ -9,16 +10,33 @@ export type ApplyCallbacks = {
   onApply: () => void;
 };
 
+export type QuickActionGenerateFunction<I, O extends Output> = (options: {
+  input: I;
+  blockIds: number[];
+  abortSignal: AbortSignal;
+  confirmationComponentId: string;
+}) => Promise<{
+  dispose: () => void;
+  returnValue: O;
+  applyCallbacks?: ApplyCallbacks;
+}>;
+
 export interface QuickActionMenu {
   id: string;
   registerQuickAction: <I, O extends Output>(
-    quickAction: QuickAction<I, O>
+    quickAction: RegisteredQuickAction<I, O>
   ) => void;
   setQuickActionMenuOrder: (quickActionIds: QuickActionId[]) => void;
   getQuickActionMenuOrder: () => string[];
   getQuickAction: <I, O extends Output>(
     magicId: QuickActionId
-  ) => QuickAction<I, O> | undefined;
+  ) => RegisteredQuickAction<I, O> | undefined;
+}
+
+export interface RegisteredQuickAction<I, O extends Output>
+  extends QuickAction<I, O> {
+  generate: QuickActionGenerateFunction<I, O>;
+  onError: ReturnType<typeof createHandleGenerationError<any, I, O>>;
 }
 
 export type InferenceStatus = 'processing' | 'confirmation';

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/types.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/types.ts
@@ -26,8 +26,6 @@ export interface QuickActionMenu {
   registerQuickAction: <I, O extends Output>(
     quickAction: RegisteredQuickAction<I, O>
   ) => void;
-  setQuickActionMenuOrder: (quickActionIds: QuickActionId[]) => void;
-  getQuickActionMenuOrder: () => string[];
   getQuickAction: <I, O extends Output>(
     magicId: QuickActionId
   ) => RegisteredQuickAction<I, O> | undefined;

--- a/packages/plugin-ai-generation-web/src/generation/quickAction/utils.ts
+++ b/packages/plugin-ai-generation-web/src/generation/quickAction/utils.ts
@@ -1,4 +1,5 @@
-import { Output, QuickAction } from '../provider';
+import { Output } from '../provider';
+import { RegisteredQuickAction } from './types';
 
 export const INFERENCE_AI_EDIT_MODE = 'ly.img.ai.inference.editMode';
 
@@ -19,8 +20,8 @@ export function getFeatureIdForQuickAction(options: {
  * actions array or if it is first or last in the array.
  */
 export function removeDuplicatedSeparators<I, O extends Output>(
-  quickActions: (QuickAction<I, O> | 'ly.img.separator')[]
-): (QuickAction<I, O> | 'ly.img.separator')[] {
+  quickActions: (RegisteredQuickAction<I, O> | 'ly.img.separator')[]
+): (RegisteredQuickAction<I, O> | 'ly.img.separator')[] {
   if (quickActions.length === 0) {
     return [];
   }
@@ -42,7 +43,7 @@ export function removeDuplicatedSeparators<I, O extends Output>(
   }
 
   // Remove consecutive separators
-  return result.reduce<(QuickAction<I, O> | 'ly.img.separator')[]>(
+  return result.reduce<(RegisteredQuickAction<I, O> | 'ly.img.separator')[]>(
     (acc, current) => {
       // Skip if current is a separator and previous was also a separator
       if (

--- a/packages/plugin-ai-generation-web/src/generation/types.ts
+++ b/packages/plugin-ai-generation-web/src/generation/types.ts
@@ -1,6 +1,16 @@
 import type CreativeEditorSDK from '@cesdk/cesdk-js';
 import { type CreativeEngine } from '@cesdk/cesdk-js';
 import type Provider from './provider';
+import { Output, OutputKind } from './provider';
+
+/**
+ * Getting a provider instance for the given CE.SDK instance.
+ */
+export type GetProvider<
+  K extends OutputKind,
+  I = any,
+  O extends Output = any
+> = ({ cesdk }: { cesdk: CreativeEditorSDK }) => Promise<Provider<K, I, O>>;
 
 /**
  * Configuration options for provider initialization

--- a/packages/plugin-ai-generation-web/src/index.ts
+++ b/packages/plugin-ai-generation-web/src/index.ts
@@ -54,6 +54,8 @@ export {
 
 export { default as registerDockComponent } from './registerDockComponent';
 
+export { type QuickActionCanvasMenuComponents } from './generation/quickAction/types';
+
 export { default as getQuickActionMenu } from './generation/quickAction/getQuickActionMenu';
 
 export { default as QuickActionBasePrompt } from './generation/quickAction/common/QuickActionBasePrompt';

--- a/packages/plugin-ai-generation-web/src/index.ts
+++ b/packages/plugin-ai-generation-web/src/index.ts
@@ -27,7 +27,10 @@ export {
   type Property
 } from './generation/openapi/types';
 export { default as initProvider } from './generation/initProvider';
-export { type GenerationMiddleware } from './generation/types';
+export {
+  type GenerationMiddleware,
+  type GetProvider
+} from './generation/types';
 
 // Export middleware
 export {

--- a/packages/plugin-ai-generation-web/src/index.ts
+++ b/packages/plugin-ai-generation-web/src/index.ts
@@ -51,7 +51,6 @@ export {
 export { default as registerDockComponent } from './registerDockComponent';
 
 export { default as getQuickActionMenu } from './generation/quickAction/getQuickActionMenu';
-export { default as registerQuickActionMenuComponent } from './generation/quickAction/registerQuickActionMenuComponent';
 
 export { default as QuickActionBasePrompt } from './generation/quickAction/common/QuickActionBasePrompt';
 export { default as QuickActionBaseButton } from './generation/quickAction/common/QuickActionBaseButton';

--- a/packages/plugin-ai-generation-web/src/index.ts
+++ b/packages/plugin-ai-generation-web/src/index.ts
@@ -27,6 +27,7 @@ export {
   type Property
 } from './generation/openapi/types';
 export { default as initProvider } from './generation/initProvider';
+export { default as enhanceProvider } from './generation/enhanceProvider';
 export {
   type GenerationMiddleware,
   type GetProvider

--- a/packages/plugin-ai-generation-web/src/index.ts
+++ b/packages/plugin-ai-generation-web/src/index.ts
@@ -56,7 +56,7 @@ export { default as registerDockComponent } from './registerDockComponent';
 
 export { type QuickActionCanvasMenuComponents } from './generation/quickAction/types';
 
-export { default as getQuickActionMenu } from './generation/quickAction/getQuickActionMenu';
+export { default as getQuickActionRegistry } from './generation/quickAction/getQuickActionRegistry';
 
 export { default as QuickActionBasePrompt } from './generation/quickAction/common/QuickActionBasePrompt';
 export { default as QuickActionBaseButton } from './generation/quickAction/common/QuickActionBaseButton';

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
@@ -81,8 +81,8 @@ function createGeminiFlashEditQuickActions(
 ): QuickAction<GeminiFlashEditInput, ImageOutput>[] {
   cesdk.i18n.setTranslations({
     en: {
-      'ly.img.ai.quickAction.styleTransfer': 'Change Art Style',
-      'ly.img.ai.quickAction.artists': 'Painted By'
+      [`ly.img.ai.quickAction.${MODEL_KEY}.styleTransfer`]: 'Change Art Style',
+      [`ly.img.ai.quickAction.${MODEL_KEY}.artists`]: 'Painted By'
     }
   });
 

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
@@ -1,5 +1,4 @@
 import {
-  getQuickActionMenu,
   ImageOutput,
   Middleware,
   QuickAction,
@@ -43,17 +42,6 @@ function getProvider(
   const modelKey = 'fal-ai/gemini-flash-edit';
 
   const quickActions = createGeminiFlashEditQuickActions(cesdk);
-  const quickActionMenu = getQuickActionMenu(cesdk, 'image');
-
-  quickActionMenu.setQuickActionMenuOrder([
-    ...quickActionMenu.getQuickActionMenuOrder(),
-    'ly.img.separator',
-    'styleTransfer',
-    'artists',
-    'ly.img.separator',
-    'changeImage',
-    'createVariant'
-  ]);
 
   return createImageProvider(
     {

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
@@ -26,16 +26,18 @@ type ProviderConfiguration = {
   middleware?: Middleware<GeminiFlashEditInput, ImageOutput>[];
 };
 
+const MODEL_KEY = 'fal-ai/gemini-flash-edit';
+
 export const GeminiFlashEdit = enhanceProvider(getProvider, {
   canvasMenu: {
     image: {
       id: 'ly.img.ai.image.canvasMenu',
       children: [
-        'fal-ai/gemini-flash-edit.styleTransfer',
-        'fal-ai/gemini-flash-edit.artists',
+        `${MODEL_KEY}.styleTransfer`,
+        `${MODEL_KEY}.artists`,
         'ly.img.separator',
-        'fal-ai/gemini-flash-edit.changeImage',
-        'fal-ai/gemini-flash-edit.createVariant'
+        `${MODEL_KEY}.changeImage`,
+        `${MODEL_KEY}.createVariant`
       ]
     }
   }
@@ -45,13 +47,11 @@ function getProvider(
   cesdk: CreativeEditorSDK,
   config: ProviderConfiguration
 ): Provider<'image', GeminiFlashEditInput, ImageOutput> {
-  const modelKey = 'fal-ai/gemini-flash-edit';
-
   const quickActions = createGeminiFlashEditQuickActions(cesdk);
 
   return createImageProvider(
     {
-      modelKey,
+      modelKey: MODEL_KEY,
       name: 'Change Image',
       // @ts-ignore
       schema,
@@ -88,17 +88,17 @@ function createGeminiFlashEditQuickActions(
 
   return [
     QuickActionSwapImageBackground<GeminiFlashEditInput, ImageOutput>({
-      id: 'fal-ai/gemini-flash-edit.swapBackground',
+      id: `${MODEL_KEY}.swapBackground`,
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionChangeImage<GeminiFlashEditInput, ImageOutput>({
-      id: 'fal-ai/gemini-flash-edit.changeImage',
+      id: `${MODEL_KEY}.changeImage`,
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionImageVariant<GeminiFlashEditInput, ImageOutput>({
-      id: 'fal-ai/gemini-flash-edit.createVariant',
+      id: `${MODEL_KEY}.createVariant`,
       onApply: async ({ prompt, uri, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -116,7 +116,7 @@ function createGeminiFlashEditQuickActions(
 
     QuickActionBaseSelect<GeminiFlashEditInput, ImageOutput>({
       quickAction: {
-        id: 'fal-ai/gemini-flash-edit.styleTransfer',
+        id: `${MODEL_KEY}.styleTransfer`,
         version: '1',
         enable: enableQuickActionForImageFill(),
         scopes: ['fill/change'],
@@ -175,7 +175,7 @@ function createGeminiFlashEditQuickActions(
 
     QuickActionBaseSelect<GeminiFlashEditInput, ImageOutput>({
       quickAction: {
-        id: 'fal-ai/gemini-flash-edit.artists',
+        id: `${MODEL_KEY}.artists`,
         version: '1',
         enable: enableQuickActionForImageFill(),
         scopes: ['fill/change'],

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
@@ -7,7 +7,8 @@ import {
   QuickActionChangeImage,
   QuickActionImageVariant,
   enableQuickActionForImageFill,
-  type Provider
+  type Provider,
+  enhanceProvider
 } from '@imgly/plugin-ai-generation-web';
 import schema from './GeminiFlashEdit.json';
 import { getImageDimensionsFromURL } from '@imgly/plugin-utils';
@@ -25,15 +26,20 @@ type ProviderConfiguration = {
   middleware?: Middleware<GeminiFlashEditInput, ImageOutput>[];
 };
 
-export function GeminiFlashEdit(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'image', GeminiFlashEditInput, ImageOutput>> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const GeminiFlashEdit = enhanceProvider(getProvider, {
+  canvasMenu: {
+    image: {
+      id: 'ly.img.ai.image.canvasMenu',
+      children: [
+        'styleTransfer',
+        'artists',
+        'ly.img.separator',
+        'changeImage',
+        'createVariant'
+      ]
+    }
+  }
+});
 
 function getProvider(
   cesdk: CreativeEditorSDK,

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
@@ -31,11 +31,11 @@ export const GeminiFlashEdit = enhanceProvider(getProvider, {
     image: {
       id: 'ly.img.ai.image.canvasMenu',
       children: [
-        'styleTransfer',
-        'artists',
+        'fal-ai/gemini-flash-edit.styleTransfer',
+        'fal-ai/gemini-flash-edit.artists',
         'ly.img.separator',
-        'changeImage',
-        'createVariant'
+        'fal-ai/gemini-flash-edit.changeImage',
+        'fal-ai/gemini-flash-edit.createVariant'
       ]
     }
   }
@@ -88,14 +88,17 @@ function createGeminiFlashEditQuickActions(
 
   return [
     QuickActionSwapImageBackground<GeminiFlashEditInput, ImageOutput>({
+      id: 'fal-ai/gemini-flash-edit.swapBackground',
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionChangeImage<GeminiFlashEditInput, ImageOutput>({
+      id: 'fal-ai/gemini-flash-edit.changeImage',
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionImageVariant<GeminiFlashEditInput, ImageOutput>({
+      id: 'fal-ai/gemini-flash-edit.createVariant',
       onApply: async ({ prompt, uri, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -113,7 +116,7 @@ function createGeminiFlashEditQuickActions(
 
     QuickActionBaseSelect<GeminiFlashEditInput, ImageOutput>({
       quickAction: {
-        id: 'styleTransfer',
+        id: 'fal-ai/gemini-flash-edit.styleTransfer',
         version: '1',
         enable: enableQuickActionForImageFill(),
         scopes: ['fill/change'],
@@ -172,7 +175,7 @@ function createGeminiFlashEditQuickActions(
 
     QuickActionBaseSelect<GeminiFlashEditInput, ImageOutput>({
       quickAction: {
-        id: 'artists',
+        id: 'fal-ai/gemini-flash-edit.artists',
         version: '1',
         enable: enableQuickActionForImageFill(),
         scopes: ['fill/change'],

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/RecraftV3.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/RecraftV3.ts
@@ -2,6 +2,7 @@ import { Icons, CustomAssetSource } from '@imgly/plugin-utils';
 import {
   Middleware,
   type Provider,
+  enhanceProvider,
   getPanelId
 } from '@imgly/plugin-ai-generation-web';
 import { type RecraftV3Input } from '@fal-ai/client/endpoints';
@@ -47,15 +48,7 @@ type ProviderConfiguration = {
 let imageStyleAssetSource: CustomAssetSource;
 let vectorStyleAssetSource: CustomAssetSource;
 
-export function RecraftV3(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'image', RecraftV3Input, RecraftV3Output>> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const RecraftV3 = enhanceProvider(getProvider);
 
 function getProvider(
   cesdk: CreativeEditorSDK,

--- a/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
+++ b/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
@@ -31,6 +31,8 @@ import {
   STYLES
 } from './GptImage1.styles';
 
+const MODEL_KEY = 'open-ai/gpt-image-1/image2image';
+
 type GptImage1Input = {
   prompt: string;
   image_url: string | string[];
@@ -53,15 +55,14 @@ export const GptImage1 = enhanceProvider(getProvider, {
     image: {
       id: 'ly.img.ai.image.canvasMenu',
       children: [
-        'open-ai/gpt-image-1/image2image.changeStyleLibrary',
-        // 'open-ai/gpt-image-1/image2image.changeStyle',
+        `${MODEL_KEY}.changeStyleLibrary`,
         'ly.img.separator',
-        'open-ai/gpt-image-1/image2image.swapBackground',
-        'open-ai/gpt-image-1/image2image.changeImage',
-        'open-ai/gpt-image-1/image2image.createVariant',
-        'open-ai/gpt-image-1/image2image.combineImages',
+        `${MODEL_KEY}.swapBackground`,
+        `${MODEL_KEY}.changeImage`,
+        `${MODEL_KEY}.createVariant`,
+        `${MODEL_KEY}.combineImages`,
         'ly.img.separator',
-        'open-ai/gpt-image-1/image2image.remixPage'
+        `${MODEL_KEY}.remixPage`
       ]
     }
   }
@@ -71,14 +72,13 @@ function getProvider(
   cesdk: CreativeEditorSDK,
   config: ProviderConfiguration
 ): Provider<'image', GptImage1Input, GptImage1Output> {
-  const modelKey = 'open-ai/gpt-image-1/image2image';
   cesdk.ui.addIconSet('@imgly/plugin/formats', Icons.Formats);
   const baseURL =
     'https://cdn.img.ly/assets/plugins/plugin-ai-image-generation-web/v1/gpt-image-1/';
 
-  const quickActions = createQuickActions({ cesdk, modelKey });
+  const quickActions = createQuickActions({ cesdk });
 
-  const styleAssetSourceId = `${modelKey}/styles`;
+  const styleAssetSourceId = `${MODEL_KEY}/styles`;
   const styleAssetSource = createStyleAssetSource(styleAssetSourceId, {
     baseURL
   });
@@ -86,20 +86,20 @@ function getProvider(
 
   cesdk.i18n.setTranslations({
     en: {
-      'ly.img.ai.quickAction.changeStyle': 'Change Style',
-      'ly.img.ai.quickAction.changeStyleLibrary': 'Change Style',
-      'ly.img.ai.quickAction.remixPage': 'Turn Page into Image',
-      'ly.img.ai.quickAction.remixPageWithPrompt': 'Remix Page',
-      'ly.img.ai.quickAction.remixPageWithPrompt.prompt.inputLabel':
+      [`ly.img.ai.quickAction.${MODEL_KEY}.changeStyle`]: 'Change Style',
+      [`ly.img.ai.quickAction.${MODEL_KEY}.changeStyleLibrary`]: 'Change Style',
+      [`ly.img.ai.quickAction.${MODEL_KEY}.remixPage`]: 'Turn Page into Image',
+      [`ly.img.ai.quickAction.${MODEL_KEY}.remixPageWithPrompt`]: 'Remix Page',
+      [`ly.img.ai.quickAction.${MODEL_KEY}.remixPageWithPrompt.prompt.inputLabel`]:
         'Remix Page Prompt',
-      'ly.img.ai.quickAction.remixPageWithPrompt.prompt.placeholder':
+      [`ly.img.ai.quickAction.${MODEL_KEY}.remixPageWithPrompt.prompt.placeholder`]:
         'e.g. rearrange the layout to...',
-      'ly.img.ai.quickAction.remixPageWithPrompt.apply': 'Remix'
+      [`ly.img.ai.quickAction.${MODEL_KEY}.remixPageWithPrompt.apply`]: 'Remix'
     }
   });
 
   const provider: Provider<'image', GptImage1Input, GptImage1Output> = {
-    id: modelKey,
+    id: MODEL_KEY,
     kind: 'image',
     name: 'gpt-image-1',
     input: {
@@ -253,15 +253,14 @@ function getProvider(
 
 function createQuickActions(options: {
   cesdk: CreativeEditorSDK;
-  modelKey: string;
 }): QuickAction<GptImage1Input, GptImage1Output>[] {
-  const { cesdk, modelKey } = options;
+  const { cesdk } = options;
   return [
     QuickActionBaseLibrary<GptImage1Input, GptImage1Output>({
       cesdk: options.cesdk,
-      entries: [`${modelKey}/styles`],
+      entries: [`${MODEL_KEY}/styles`],
       quickAction: {
-        id: 'open-ai/gpt-image-1/image2image.changeStyleLibrary',
+        id: `${MODEL_KEY}.changeStyleLibrary`,
         version: '1',
         confirmation: true,
         lockDuringConfirmation: false,
@@ -290,7 +289,7 @@ function createQuickActions(options: {
       cesdk,
       items: STYLES.filter(({ id }) => id !== 'none'),
       quickAction: {
-        id: 'open-ai/gpt-image-1/image2image.changeStyle',
+        id: `${MODEL_KEY}.changeStyle`,
         version: '1',
         confirmation: true,
         lockDuringConfirmation: false,
@@ -310,7 +309,7 @@ function createQuickActions(options: {
       }
     }),
     QuickActionEditTextStyle<GptImage1Input, GptImage1Output>({
-      id: 'open-ai/gpt-image-1/image2image.editTextStyle',
+      id: `${MODEL_KEY}.editTextStyle`,
       onApply: async ({ prompt, uri, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -326,17 +325,17 @@ function createQuickActions(options: {
       cesdk
     }),
     QuickActionSwapImageBackground<GptImage1Input, GptImage1Output>({
-      id: 'open-ai/gpt-image-1/image2image.swapBackground',
+      id: `${MODEL_KEY}.swapBackground`,
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionChangeImage<GptImage1Input, GptImage1Output>({
-      id: 'open-ai/gpt-image-1/image2image.changeImage',
+      id: `${MODEL_KEY}.changeImage`,
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionImageVariant<GptImage1Input, GptImage1Output>({
-      id: 'open-ai/gpt-image-1/image2image.createVariant',
+      id: `${MODEL_KEY}.createVariant`,
       onApply: async ({ prompt, uri, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -352,7 +351,7 @@ function createQuickActions(options: {
       cesdk
     }),
     QuickActionCombineImages<GptImage1Input, GptImage1Output>({
-      id: 'open-ai/gpt-image-1/image2image.combineImages',
+      id: `${MODEL_KEY}.combineImages`,
       onApply: async ({ prompt, uris, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -370,7 +369,7 @@ function createQuickActions(options: {
     }),
     QuickActionBaseButton<GptImage1Input, GptImage1Output>({
       quickAction: {
-        id: 'open-ai/gpt-image-1/image2image.remixPage',
+        id: `${MODEL_KEY}.remixPage`,
         version: '1',
         confirmation: false,
         lockDuringConfirmation: false,
@@ -437,7 +436,7 @@ function createQuickActions(options: {
     }),
     QuickActionBasePrompt<GptImage1Input, GptImage1Output>({
       quickAction: {
-        id: 'open-ai/gpt-image-1/image2image.remixPageWithPrompt',
+        id: `${MODEL_KEY}.remixPageWithPrompt`,
         version: '1',
         confirmation: false,
         lockDuringConfirmation: false,

--- a/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
+++ b/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
@@ -53,15 +53,15 @@ export const GptImage1 = enhanceProvider(getProvider, {
     image: {
       id: 'ly.img.ai.image.canvasMenu',
       children: [
-        'changeStyleLibrary',
-        // 'changeStyle',
+        'open-ai/gpt-image-1/image2image.changeStyleLibrary',
+        // 'open-ai/gpt-image-1/image2image.changeStyle',
         'ly.img.separator',
-        'swapBackground',
-        'changeImage',
-        'createVariant',
-        'combineImages',
+        'open-ai/gpt-image-1/image2image.swapBackground',
+        'open-ai/gpt-image-1/image2image.changeImage',
+        'open-ai/gpt-image-1/image2image.createVariant',
+        'open-ai/gpt-image-1/image2image.combineImages',
         'ly.img.separator',
-        'remixPage'
+        'open-ai/gpt-image-1/image2image.remixPage'
       ]
     }
   }
@@ -261,7 +261,7 @@ function createQuickActions(options: {
       cesdk: options.cesdk,
       entries: [`${modelKey}/styles`],
       quickAction: {
-        id: 'changeStyleLibrary',
+        id: 'open-ai/gpt-image-1/image2image.changeStyleLibrary',
         version: '1',
         confirmation: true,
         lockDuringConfirmation: false,
@@ -290,7 +290,7 @@ function createQuickActions(options: {
       cesdk,
       items: STYLES.filter(({ id }) => id !== 'none'),
       quickAction: {
-        id: 'changeStyle',
+        id: 'open-ai/gpt-image-1/image2image.changeStyle',
         version: '1',
         confirmation: true,
         lockDuringConfirmation: false,
@@ -310,6 +310,7 @@ function createQuickActions(options: {
       }
     }),
     QuickActionEditTextStyle<GptImage1Input, GptImage1Output>({
+      id: 'open-ai/gpt-image-1/image2image.editTextStyle',
       onApply: async ({ prompt, uri, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -325,14 +326,17 @@ function createQuickActions(options: {
       cesdk
     }),
     QuickActionSwapImageBackground<GptImage1Input, GptImage1Output>({
+      id: 'open-ai/gpt-image-1/image2image.swapBackground',
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionChangeImage<GptImage1Input, GptImage1Output>({
+      id: 'open-ai/gpt-image-1/image2image.changeImage',
       mapInput: (input) => ({ ...input, image_url: input.uri }),
       cesdk
     }),
     QuickActionImageVariant<GptImage1Input, GptImage1Output>({
+      id: 'open-ai/gpt-image-1/image2image.createVariant',
       onApply: async ({ prompt, uri, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -348,6 +352,7 @@ function createQuickActions(options: {
       cesdk
     }),
     QuickActionCombineImages<GptImage1Input, GptImage1Output>({
+      id: 'open-ai/gpt-image-1/image2image.combineImages',
       onApply: async ({ prompt, uris, duplicatedBlockId }, context) => {
         // Generate a variant for the duplicated block
         return context.generate(
@@ -365,7 +370,7 @@ function createQuickActions(options: {
     }),
     QuickActionBaseButton<GptImage1Input, GptImage1Output>({
       quickAction: {
-        id: 'remixPage',
+        id: 'open-ai/gpt-image-1/image2image.remixPage',
         version: '1',
         confirmation: false,
         lockDuringConfirmation: false,
@@ -432,7 +437,7 @@ function createQuickActions(options: {
     }),
     QuickActionBasePrompt<GptImage1Input, GptImage1Output>({
       quickAction: {
-        id: 'remixPageWithPrompt',
+        id: 'open-ai/gpt-image-1/image2image.remixPageWithPrompt',
         version: '1',
         confirmation: false,
         lockDuringConfirmation: false,

--- a/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
+++ b/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
@@ -12,7 +12,6 @@ import {
   QuickActionEditTextStyle,
   QuickActionSwapImageBackground,
   CommonProperties,
-  getQuickActionMenu,
   Middleware,
   QuickActionBasePrompt,
   QuickAction,
@@ -68,8 +67,6 @@ function getProvider(
     'https://cdn.img.ly/assets/plugins/plugin-ai-image-generation-web/v1/gpt-image-1/';
 
   const quickActions = createQuickActions({ cesdk, modelKey });
-  const quickActionMenu = getQuickActionMenu(cesdk, 'image');
-  const quickActionMenuForText = getQuickActionMenu(cesdk, 'text');
 
   const styleAssetSourceId = `${modelKey}/styles`;
   const styleAssetSource = createStyleAssetSource(styleAssetSourceId, {
@@ -90,26 +87,6 @@ function getProvider(
       'ly.img.ai.quickAction.remixPageWithPrompt.apply': 'Remix'
     }
   });
-
-  quickActionMenu.setQuickActionMenuOrder([
-    'changeStyleLibrary',
-    // 'changeStyle',
-    'ly.img.separator',
-    'swapBackground',
-    'changeImage',
-    'createVariant',
-    'combineImages',
-    'ly.img.separator',
-    'remixPage',
-    'ly.img.separator',
-    ...quickActionMenu.getQuickActionMenuOrder()
-  ]);
-
-  quickActionMenuForText.setQuickActionMenuOrder([
-    ...quickActionMenuForText.getQuickActionMenuOrder(),
-    'ly.img.separator',
-    'changeToImage'
-  ]);
 
   const provider: Provider<'image', GptImage1Input, GptImage1Output> = {
     id: modelKey,

--- a/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
+++ b/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
@@ -19,7 +19,8 @@ import {
   QuickActionBaseSelect,
   QuickActionBaseLibrary,
   enableQuickActionForImageFill,
-  QuickActionBaseButton
+  QuickActionBaseButton,
+  enhanceProvider
 } from '@imgly/plugin-ai-generation-web';
 import GptImage1Schema from './GptImage1.image2image.json';
 import CreativeEditorSDK, { MimeType } from '@cesdk/cesdk-js';
@@ -47,15 +48,24 @@ type ProviderConfiguration = {
   middleware?: Middleware<GptImage1Input, GptImage1Output>[];
 };
 
-export function GptImage1(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'image', GptImage1Input, GptImage1Output>> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const GptImage1 = enhanceProvider(getProvider, {
+  canvasMenu: {
+    image: {
+      id: 'ly.img.ai.image.canvasMenu',
+      children: [
+        'changeStyleLibrary',
+        // 'changeStyle',
+        'ly.img.separator',
+        'swapBackground',
+        'changeImage',
+        'createVariant',
+        'combineImages',
+        'ly.img.separator',
+        'remixPage'
+      ]
+    }
+  }
+});
 
 function getProvider(
   cesdk: CreativeEditorSDK,

--- a/packages/plugin-ai-text-generation-web/README.md
+++ b/packages/plugin-ai-text-generation-web/README.md
@@ -53,11 +53,8 @@ CreativeEditorSDK.create(domElement, {
         })
     );
 
-    // Set canvas menu order to display AI text actions
-    cesdk.ui.setCanvasMenuOrder([
-        'ly.img.ai.text.canvasMenu',
-        ...cesdk.ui.getCanvasMenuOrder()
-    ]);
+    // Note: Canvas menu quick actions are automatically added by the provider
+    // The text quick actions are available via: Anthropic.AnthropicProvider.canvasMenu.text
 });
 ```
 
@@ -222,11 +219,102 @@ The plugin adds a "Magic Menu" to the canvas context menu for text blocks with t
 -   **Translate**: Translate text to various languages
 -   **Change Text to...**: Completely rewrite text based on a custom prompt
 
-To add the AI text menu to your canvas menu, use:
+The AI text menu is automatically added to the canvas menu by the enhanced provider. You can access the canvas menu component ID via:
 
 ```typescript
+// Access the canvas menu ID from the enhanced provider
+const textCanvasMenuId = Anthropic.AnthropicProvider.canvasMenu.text.id; // 'ly.img.ai.text.canvasMenu'
+
+// Manual canvas menu ordering (if needed)
 cesdk.ui.setCanvasMenuOrder([
-    'ly.img.ai.text.canvasMenu',
+    Anthropic.AnthropicProvider.canvasMenu.text.id,
+    ...cesdk.ui.getCanvasMenuOrder()
+]);
+```
+
+### Canvas Menu Control
+
+If you need full control over canvas menu integration, you can disable automatic registration:
+
+```typescript
+provider: Anthropic.AnthropicProvider({
+    proxyUrl: 'https://your-anthropic-proxy.example.com',
+    addToCanvasMenu: false // Disable automatic canvas menu registration
+})
+
+// You are now responsible for manually adding the canvas menu components
+cesdk.ui.setCanvasMenuOrder([
+    {
+        id: Anthropic.AnthropicProvider.canvasMenu.text.id,
+        children: Anthropic.AnthropicProvider.canvasMenu.text.children
+    },
+    ...cesdk.ui.getCanvasMenuOrder()
+]);
+```
+
+## Anthropic Provider Quick Actions
+
+The Anthropic provider automatically registers the following quick actions in the text canvas menu (in this default order):
+
+### Default Quick Action Order
+
+| Quick Action ID | Label | Description | Icon |
+|-----------------|-------|-------------|------|
+| `anthropic.improve` | Improve | Enhance the quality and clarity of text | @imgly/MagicWand |
+| `anthropic.fix` | Fix Spelling & Grammar | Correct language errors in text | @imgly/CheckmarkAll |
+| `anthropic.shorter` | Make Shorter | Create a more concise version of the text | @imgly/TextShorter |
+| `anthropic.longer` | Make Longer | Expand text with additional details | @imgly/TextLonger |
+| `ly.img.separator` | — | Visual separator | — |
+| `anthropic.changeTone` | Change Tone | Modify tone (professional, casual, friendly, etc.) | @imgly/Microphone |
+| `anthropic.translate` | Translate | Translate text to various languages | @imgly/Language |
+| `ly.img.separator` | — | Visual separator | — |
+| `anthropic.changeTextTo` | Change Text to... | Completely rewrite text based on custom prompt | @imgly/Rename |
+
+### Canvas Menu Component Information
+
+```typescript
+// Access the Anthropic provider's canvas menu information
+Anthropic.AnthropicProvider.canvasMenu.text = {
+    id: 'ly.img.ai.text.canvasMenu',
+    children: [
+        'anthropic.improve',
+        'anthropic.fix', 
+        'anthropic.shorter',
+        'anthropic.longer',
+        'ly.img.separator',
+        'anthropic.changeTone',
+        'anthropic.translate',
+        'ly.img.separator',
+        'anthropic.changeTextTo'
+    ]
+}
+```
+
+### Customizing Quick Action Order
+
+To customize the order of text quick actions, disable automatic canvas menu registration and configure manually:
+
+```typescript
+// Configure provider without automatic canvas menu registration
+provider: Anthropic.AnthropicProvider({
+    proxyUrl: 'https://your-anthropic-proxy.example.com',
+    addToCanvasMenu: false
+})
+
+// Manually configure canvas menu with custom order
+cesdk.ui.setCanvasMenuOrder([
+    {
+        id: 'ly.img.ai.text.canvasMenu',
+        children: [
+            'anthropic.improve',      // Most commonly used first
+            'anthropic.fix',
+            'ly.img.separator',
+            'anthropic.changeTone',   // Advanced options
+            'anthropic.translate',
+            'anthropic.changeTextTo'
+            // Note: removed shorter/longer for a more focused menu
+        ]
+    },
     ...cesdk.ui.getCanvasMenuOrder()
 ]);
 ```

--- a/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
+++ b/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
@@ -16,6 +16,8 @@ import translate, { LANGUAGES, LOCALES } from './prompts/translate';
 import changeTone from './prompts/changeTone';
 import changeTextTo from './prompts/changeTextTo';
 
+const MODEL_KEY = 'anthropic';
+
 type ProviderConfiguration = {
   proxyUrl: string;
   debug?: boolean;
@@ -41,15 +43,15 @@ export const AnthropicProvider = enhanceProvider(getProvider, {
     text: {
       id: 'ly.img.ai.text.canvasMenu',
       children: [
-        'anthropic.improve',
-        'anthropic.fix',
-        'anthropic.shorter',
-        'anthropic.longer',
+        `${MODEL_KEY}.improve`,
+        `${MODEL_KEY}.fix`,
+        `${MODEL_KEY}.shorter`,
+        `${MODEL_KEY}.longer`,
         'ly.img.separator',
-        'anthropic.changeTone',
-        'anthropic.translate',
+        `${MODEL_KEY}.changeTone`,
+        `${MODEL_KEY}.translate`,
         'ly.img.separator',
-        'anthropic.changeTextTo'
+        `${MODEL_KEY}.changeTextTo`
       ]
     }
   }
@@ -59,8 +61,8 @@ function getProvider(cesdk: CreativeEditorSDK, config: ProviderConfiguration) {
   cesdk.i18n.setTranslations({
     en: {
       ...Object.entries(LANGUAGES).reduce(
-        (acc: Record<string, string>, [locale, langauge]) => {
-          acc[`ly.img.ai.inference.translate.type.${locale}`] = langauge;
+        (acc: Record<string, string>, [locale, language]) => {
+          acc[`ly.img.ai.inference.translate.type.${locale}`] = language;
           return acc;
         },
         {}
@@ -316,7 +318,7 @@ function createTextQuickAction(
 
 function ImproveQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'anthropic.improve',
+    id: `${MODEL_KEY}.improve`,
     label: 'Improve',
     icon: '@imgly/MagicWand',
     promptFn: improve
@@ -325,7 +327,7 @@ function ImproveQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function ShorterQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'anthropic.shorter',
+    id: `${MODEL_KEY}.shorter`,
     label: 'Make Shorter',
     icon: '@imgly/TextShorter',
     promptFn: shorter
@@ -334,7 +336,7 @@ function ShorterQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function LongerQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'anthropic.longer',
+    id: `${MODEL_KEY}.longer`,
     label: 'Make Longer',
     icon: '@imgly/TextLonger',
     promptFn: longer
@@ -343,7 +345,7 @@ function LongerQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function FixQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'anthropic.fix',
+    id: `${MODEL_KEY}.fix`,
     label: 'Fix Spelling & Grammar',
     icon: '@imgly/CheckmarkAll',
     promptFn: fix
@@ -352,7 +354,7 @@ function FixQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function SpeechQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'anthropic.speech',
+    id: `${MODEL_KEY}.speech`,
     label: 'Generate Speech Text',
     icon: '@imgly/Microphone',
     promptFn: generateTextForSpeech
@@ -370,7 +372,7 @@ const TONE_TYPES = [
 
 function ChangeToneQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'anthropic.changeTone',
+    id: `${MODEL_KEY}.changeTone`,
     label: 'Change Tone',
     icon: '@imgly/Microphone',
     promptFn: changeTone,
@@ -383,7 +385,7 @@ function ChangeToneQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function TranslateQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'anthropic.translate',
+    id: `${MODEL_KEY}.translate`,
     label: 'Translate',
     icon: '@imgly/Language',
     promptFn: translate,
@@ -399,7 +401,7 @@ function ChangeTextToQuickAction(): QuickAction<
   AnthropicOutput
 > {
   return createTextQuickAction({
-    id: 'anthropic.changeTextTo',
+    id: `${MODEL_KEY}.changeTextTo`,
     label: 'Change Text to...',
     icon: '@imgly/Rename',
     promptFn: changeTextTo,

--- a/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
+++ b/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
@@ -41,15 +41,15 @@ export const AnthropicProvider = enhanceProvider(getProvider, {
     text: {
       id: 'ly.img.ai.text.canvasMenu',
       children: [
-        'improve',
-        'fix',
-        'shorter',
-        'longer',
+        'anthropic.improve',
+        'anthropic.fix',
+        'anthropic.shorter',
+        'anthropic.longer',
         'ly.img.separator',
-        'changeTone',
-        'translate',
+        'anthropic.changeTone',
+        'anthropic.translate',
         'ly.img.separator',
-        'changeTextTo'
+        'anthropic.changeTextTo'
       ]
     }
   }
@@ -316,7 +316,7 @@ function createTextQuickAction(
 
 function ImproveQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'improve',
+    id: 'anthropic.improve',
     label: 'Improve',
     icon: '@imgly/MagicWand',
     promptFn: improve
@@ -325,7 +325,7 @@ function ImproveQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function ShorterQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'shorter',
+    id: 'anthropic.shorter',
     label: 'Make Shorter',
     icon: '@imgly/TextShorter',
     promptFn: shorter
@@ -334,7 +334,7 @@ function ShorterQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function LongerQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'longer',
+    id: 'anthropic.longer',
     label: 'Make Longer',
     icon: '@imgly/TextLonger',
     promptFn: longer
@@ -343,7 +343,7 @@ function LongerQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function FixQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'fix',
+    id: 'anthropic.fix',
     label: 'Fix Spelling & Grammar',
     icon: '@imgly/CheckmarkAll',
     promptFn: fix
@@ -352,7 +352,7 @@ function FixQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function SpeechQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'speech',
+    id: 'anthropic.speech',
     label: 'Generate Speech Text',
     icon: '@imgly/Microphone',
     promptFn: generateTextForSpeech
@@ -370,7 +370,7 @@ const TONE_TYPES = [
 
 function ChangeToneQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'changeTone',
+    id: 'anthropic.changeTone',
     label: 'Change Tone',
     icon: '@imgly/Microphone',
     promptFn: changeTone,
@@ -383,7 +383,7 @@ function ChangeToneQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
 
 function TranslateQuickAction(): QuickAction<AnthropicInput, AnthropicOutput> {
   return createTextQuickAction({
-    id: 'translate',
+    id: 'anthropic.translate',
     label: 'Translate',
     icon: '@imgly/Language',
     promptFn: translate,
@@ -399,7 +399,7 @@ function ChangeTextToQuickAction(): QuickAction<
   AnthropicOutput
 > {
   return createTextQuickAction({
-    id: 'changeTextTo',
+    id: 'anthropic.changeTextTo',
     label: 'Change Text to...',
     icon: '@imgly/Rename',
     promptFn: changeTextTo,

--- a/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
+++ b/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
@@ -1,5 +1,6 @@
 import CreativeEditorSDK from '@cesdk/cesdk-js';
 import {
+  enhanceProvider,
   Middleware,
   Provider,
   QuickAction
@@ -35,115 +36,128 @@ type AnthropicOutput = {
   text: string;
 };
 
-export function AnthropicProvider(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'text', AnthropicInput, AnthropicOutput>> {
-  return (context: { cesdk: CreativeEditorSDK }) => {
-    context.cesdk.i18n.setTranslations({
-      en: {
-        ...Object.entries(LANGUAGES).reduce(
-          (acc: Record<string, string>, [locale, langauge]) => {
-            acc[`ly.img.ai.inference.translate.type.${locale}`] = langauge;
-            return acc;
-          },
-          {}
-        )
+export const AnthropicProvider = enhanceProvider(getProvider, {
+  canvasMenu: {
+    text: {
+      id: 'ly.img.ai.text.canvasMenu',
+      children: [
+        'improve',
+        'fix',
+        'shorter',
+        'longer',
+        'ly.img.separator',
+        'changeTone',
+        'translate',
+        'ly.img.separator',
+        'changeTextTo'
+      ]
+    }
+  }
+});
+
+function getProvider(cesdk: CreativeEditorSDK, config: ProviderConfiguration) {
+  cesdk.i18n.setTranslations({
+    en: {
+      ...Object.entries(LANGUAGES).reduce(
+        (acc: Record<string, string>, [locale, langauge]) => {
+          acc[`ly.img.ai.inference.translate.type.${locale}`] = langauge;
+          return acc;
+        },
+        {}
+      )
+    }
+  });
+
+  let anthropic: Anthropic | null = null;
+  const provider: Provider<'text', AnthropicInput, AnthropicOutput> = {
+    kind: 'text',
+    id: 'anthropic',
+    initialize: async () => {
+      anthropic = new Anthropic({
+        dangerouslyAllowBrowser: true,
+        baseURL: config.proxyUrl,
+        // Will be injected by the proxy
+        apiKey: null,
+        authToken: null
+      });
+    },
+    input: {
+      quickActions: {
+        actions: [
+          ImproveQuickAction(),
+          FixQuickAction(),
+          ShorterQuickAction(),
+          LongerQuickAction(),
+          SpeechQuickAction(),
+          ChangeToneQuickAction(),
+          TranslateQuickAction(),
+          ChangeTextToQuickAction()
+        ]
       }
-    });
+    },
+    output: {
+      middleware: config.middleware,
+      generate: async (
+        { prompt, blockId },
+        { engine, abortSignal }
+      ): Promise<AsyncGenerator<AnthropicOutput, AnthropicOutput>> => {
+        if (anthropic == null)
+          throw new Error('Anthropic SDK is not initialized');
 
-    let anthropic: Anthropic | null = null;
-    const provider: Provider<'text', AnthropicInput, AnthropicOutput> = {
-      kind: 'text',
-      id: 'anthropic',
-      initialize: async () => {
-        anthropic = new Anthropic({
-          dangerouslyAllowBrowser: true,
-          baseURL: config.proxyUrl,
-          // Will be injected by the proxy
-          apiKey: null,
-          authToken: null
-        });
-      },
-      input: {
-        quickActions: {
-          actions: [
-            ImproveQuickAction(),
-            FixQuickAction(),
-            ShorterQuickAction(),
-            LongerQuickAction(),
-            SpeechQuickAction(),
-            ChangeToneQuickAction(),
-            TranslateQuickAction(),
-            ChangeTextToQuickAction()
-          ]
+        if (
+          blockId != null &&
+          engine.block.getType(blockId) !== '//ly.img.ubq/text'
+        ) {
+          throw new Error(
+            'If a block is provided to this generation, it most be a text block'
+          );
         }
-      },
-      output: {
-        middleware: config.middleware,
-        generate: async (
-          { prompt, blockId },
-          { engine, abortSignal }
-        ): Promise<AsyncGenerator<AnthropicOutput, AnthropicOutput>> => {
-          if (anthropic == null)
-            throw new Error('Anthropic SDK is not initialized');
 
-          if (
-            blockId != null &&
-            engine.block.getType(blockId) !== '//ly.img.ubq/text'
-          ) {
-            throw new Error(
-              'If a block is provided to this generation, it most be a text block'
-            );
-          }
-
-          if (config.debug)
-            // eslint-disable-next-line no-console
-            console.log(
-              'Sending prompt to Anthropic:',
-              JSON.stringify(prompt, undefined, 2)
-            );
-
-          const stream = await sendPrompt(
-            anthropic,
-            {
-              proxyUrl: config.proxyUrl
-            },
-            prompt,
-            abortSignal
+        if (config.debug)
+          // eslint-disable-next-line no-console
+          console.log(
+            'Sending prompt to Anthropic:',
+            JSON.stringify(prompt, undefined, 2)
           );
 
-          // Create a new AsyncGenerator that yields AnthropicOutput objects
-          async function* outputGenerator(): AsyncGenerator<
-            AnthropicOutput,
-            AnthropicOutput
-          > {
-            let inferredText: string = '';
-            for await (const chunk of stream) {
-              if (abortSignal.aborted) {
-                break;
-              }
-              inferredText += chunk;
-              yield {
-                kind: 'text',
-                text: inferredText
-              };
+        const stream = await sendPrompt(
+          anthropic,
+          {
+            proxyUrl: config.proxyUrl
+          },
+          prompt,
+          abortSignal
+        );
+
+        // Create a new AsyncGenerator that yields AnthropicOutput objects
+        async function* outputGenerator(): AsyncGenerator<
+          AnthropicOutput,
+          AnthropicOutput
+        > {
+          let inferredText: string = '';
+          for await (const chunk of stream) {
+            if (abortSignal.aborted) {
+              break;
             }
-            // Return the final result
-            return {
+            inferredText += chunk;
+            yield {
               kind: 'text',
               text: inferredText
             };
           }
-
-          return outputGenerator();
+          // Return the final result
+          return {
+            kind: 'text',
+            text: inferredText
+          };
         }
-      }
-    };
 
-    return Promise.resolve(provider);
+        return outputGenerator();
+      }
+    }
   };
+
+  return Promise.resolve(provider);
 }
 
 type Parameter = {

--- a/packages/plugin-ai-text-generation-web/src/plugin.ts
+++ b/packages/plugin-ai-text-generation-web/src/plugin.ts
@@ -1,10 +1,7 @@
 import { type EditorPlugin } from '@cesdk/cesdk-js';
 import iconSprite, { PLUGIN_ICON_SET_ID } from './iconSprite';
 import { PluginConfiguration } from './types';
-import {
-  getQuickActionMenu,
-  initProvider
-} from '@imgly/plugin-ai-generation-web';
+import { initProvider } from '@imgly/plugin-ai-generation-web';
 
 export { PLUGIN_ID } from './constants';
 
@@ -22,21 +19,6 @@ export default (
         { cesdk, engine: cesdk.engine },
         { debug: config.debug ?? false, dryRun: false }
       );
-
-      const quickActionMenu = getQuickActionMenu(cesdk, 'text');
-
-      quickActionMenu.setQuickActionMenuOrder([
-        'improve',
-        'fix',
-        'shorter',
-        'longer',
-        'ly.img.separator',
-        'changeTone',
-        'translate',
-        'ly.img.separator',
-        'changeTextTo',
-        ...quickActionMenu.getQuickActionMenuOrder()
-      ]);
 
       cesdk.ui.addIconSet(PLUGIN_ICON_SET_ID, iconSprite);
       cesdk.setTranslations({

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01Live.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01Live.ts
@@ -1,5 +1,6 @@
 import { type MinimaxVideo01LiveInput } from '@fal-ai/client/endpoints';
 import {
+  enhanceProvider,
   Middleware,
   VideoOutput,
   type Provider
@@ -14,15 +15,7 @@ type ProviderConfiguration = {
   middleware?: Middleware<MinimaxVideo01LiveInput, VideoOutput>[];
 };
 
-export function MinimaxVideo01Live(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'video', MinimaxVideo01LiveInput, VideoOutput>> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const MinimaxVideo01Live = enhanceProvider(getProvider);
 
 function getProvider(
   cesdk: CreativeEditorSDK,
@@ -50,5 +43,3 @@ function getProvider(
     config
   );
 }
-
-export default getProvider;

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
@@ -5,7 +5,8 @@ import {
   QuickAction,
   type Provider,
   QuickActionBaseButton,
-  enableQuickActionForImageFill
+  enableQuickActionForImageFill,
+  enhanceProvider
 } from '@imgly/plugin-ai-generation-web';
 import { getImageDimensionsFromURL, getImageUri } from '@imgly/plugin-utils';
 import schema from './MinimaxVideo01LiveImageToVideo.json';
@@ -18,17 +19,14 @@ type ProviderConfiguration = {
   middleware?: Middleware<MinimaxVideo01LiveImageToVideoInput, VideoOutput>[];
 };
 
-export function MinimaxVideo01LiveImageToVideo(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<
-  Provider<'video', MinimaxVideo01LiveImageToVideoInput, VideoOutput>
-> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const MinimaxVideo01LiveImageToVideo = enhanceProvider(getProvider, {
+  canvasMenu: {
+    image: {
+      id: 'ly.img.ai.image.canvasMenu',
+      children: ['ly.img.separator', 'ly.img.separator', 'createVideo']
+    }
+  }
+});
 
 function getProvider(
   cesdk: CreativeEditorSDK,
@@ -108,5 +106,3 @@ function getQuickActions(
     })
   ];
 }
-
-export default getProvider;

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
@@ -5,8 +5,7 @@ import {
   QuickAction,
   type Provider,
   QuickActionBaseButton,
-  enableQuickActionForImageFill,
-  getQuickActionMenu
+  enableQuickActionForImageFill
 } from '@imgly/plugin-ai-generation-web';
 import { getImageDimensionsFromURL, getImageUri } from '@imgly/plugin-utils';
 import schema from './MinimaxVideo01LiveImageToVideo.json';
@@ -40,13 +39,6 @@ function getProvider(
   { kind: 'video'; url: string }
 > {
   const quickActions = getQuickActions(cesdk);
-  const quickActionMenu = getQuickActionMenu(cesdk, 'image');
-
-  quickActionMenu.setQuickActionMenuOrder([
-    ...quickActionMenu.getQuickActionMenuOrder(),
-    'ly.img.separator',
-    'createVideo'
-  ]);
 
   return createVideoProvider(
     {

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
@@ -19,11 +19,13 @@ type ProviderConfiguration = {
   middleware?: Middleware<MinimaxVideo01LiveImageToVideoInput, VideoOutput>[];
 };
 
+const MODEL_KEY = 'fal-ai/minimax/video-01-live/image-to-video';
+
 export const MinimaxVideo01LiveImageToVideo = enhanceProvider(getProvider, {
   canvasMenu: {
     image: {
       id: 'ly.img.ai.image.canvasMenu',
-      children: ['ly.img.separator', 'ly.img.separator', 'fal-ai/minimax/video-01-live/image-to-video.createVideo']
+      children: ['ly.img.separator', `${MODEL_KEY}.createVideo`]
     }
   }
 });
@@ -40,7 +42,7 @@ function getProvider(
 
   return createVideoProvider(
     {
-      modelKey: 'fal-ai/minimax/video-01-live/image-to-video',
+      modelKey: MODEL_KEY,
       // @ts-ignore
       schema,
       inputReference:
@@ -79,7 +81,7 @@ function getQuickActions(
   return [
     QuickActionBaseButton<MinimaxVideo01LiveImageToVideoInput, VideoOutput>({
       quickAction: {
-        id: 'fal-ai/minimax/video-01-live/image-to-video.createVideo',
+        id: `${MODEL_KEY}.createVideo`,
         kind: 'image',
         version: '1',
         enable: enableQuickActionForImageFill()
@@ -99,7 +101,7 @@ function getQuickActions(
           'fromImage'
         );
         cesdk.ui.experimental.setGlobalStateValue(
-          'fal-ai/minimax/video-01-live/image-to-video.image_url',
+          `${MODEL_KEY}.image_url`,
           uri
         );
       }

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
@@ -74,7 +74,7 @@ function getQuickActions(
 ): QuickAction<MinimaxVideo01LiveImageToVideoInput, VideoOutput>[] {
   cesdk.i18n.setTranslations({
     en: {
-      'ly.img.ai.quickAction.createVideo': 'Create Video...'
+      [`ly.img.ai.quickAction.${MODEL_KEY}.createVideo`]: 'Create Video...'
     }
   });
 

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
@@ -23,7 +23,7 @@ export const MinimaxVideo01LiveImageToVideo = enhanceProvider(getProvider, {
   canvasMenu: {
     image: {
       id: 'ly.img.ai.image.canvasMenu',
-      children: ['ly.img.separator', 'ly.img.separator', 'createVideo']
+      children: ['ly.img.separator', 'ly.img.separator', 'fal-ai/minimax/video-01-live/image-to-video.createVideo']
     }
   }
 });
@@ -79,7 +79,7 @@ function getQuickActions(
   return [
     QuickActionBaseButton<MinimaxVideo01LiveImageToVideoInput, VideoOutput>({
       quickAction: {
-        id: 'createVideo',
+        id: 'fal-ai/minimax/video-01-live/image-to-video.createVideo',
         kind: 'image',
         version: '1',
         enable: enableQuickActionForImageFill()

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/PixverseV35TextToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/PixverseV35TextToVideo.ts
@@ -1,4 +1,5 @@
 import {
+  enhanceProvider,
   Middleware,
   VideoOutput,
   type Provider
@@ -20,15 +21,7 @@ type PixverseV35TextToVideoInput = {
   duration?: '5s' | '8s';
 };
 
-export function PixverseV35TextToVideo(
-  config: ProviderConfiguration
-): (context: {
-  cesdk: CreativeEditorSDK;
-}) => Promise<Provider<'video', PixverseV35TextToVideoInput, VideoOutput>> {
-  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
-    return getProvider(cesdk, config);
-  };
-}
+export const PixverseV35TextToVideo = enhanceProvider(getProvider);
 
 function getProvider(
   cesdk: CreativeEditorSDK,

--- a/packages/plugin-utils/src/index.ts
+++ b/packages/plugin-utils/src/index.ts
@@ -24,6 +24,8 @@ export { default as registerFillProcessingComponents } from './processing/regist
 
 export { type Optional } from './types/Optional';
 
+export { type ReturnType } from './types/ReturnType';
+
 export {
   type Location,
   type UserInterfaceConfiguration

--- a/packages/plugin-utils/src/types/ReturnType.ts
+++ b/packages/plugin-utils/src/types/ReturnType.ts
@@ -1,0 +1,5 @@
+/**
+ * Gives the return type of a function.
+ * @public
+ */
+export type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any;


### PR DESCRIPTION
-   [all] Quick action entries are now defined by `children` of a canvas menu component (set by `setCanvasMenuOrder`)
-   [all] Prefix quick action IDs with provider model keys to prevent conflicts
-   [all] All providers automatically add quick actions to the canvas menu (use `addQuickAction: false` to customize)
-   [ai-generation] Add `enhanceProvider` helper function for automatic canvas menu integration
