### PR TITLE
Add runtime version consistency checking for AI plugins

### DIFF
--- a/packages/plugin-ai-apps-web/src/plugin.ts
+++ b/packages/plugin-ai-apps-web/src/plugin.ts
@@ -3,7 +3,11 @@ import CreativeEditorSDK, {
   AssetLibraryDockComponent,
   EditorPlugin
 } from '@cesdk/cesdk-js';
-import { getPanelId, ActionRegistry } from '@imgly/plugin-ai-generation-web';
+import {
+  getPanelId,
+  ActionRegistry,
+  checkAiPluginVersion
+} from '@imgly/plugin-ai-generation-web';
 
 import ImageGeneration from '@imgly/plugin-ai-image-generation-web';
 import VideoGeneration from '@imgly/plugin-ai-video-generation-web';
@@ -11,6 +15,7 @@ import AudioGeneration from '@imgly/plugin-ai-audio-generation-web';
 import TextGeneration from '@imgly/plugin-ai-text-generation-web';
 import { createCustomAssetSource } from './ActiveAssetSource';
 import { PluginConfiguration } from './types';
+import { PLUGIN_ID } from './constants';
 
 export { PLUGIN_ID } from './constants';
 
@@ -24,6 +29,9 @@ export default (
   return {
     async initialize({ cesdk }) {
       if (cesdk == null) return;
+
+      // Check AI plugin version consistency
+      checkAiPluginVersion(cesdk, PLUGIN_ID, PLUGIN_VERSION);
 
       const { providers } = config;
 

--- a/packages/plugin-ai-audio-generation-web/src/plugin.ts
+++ b/packages/plugin-ai-audio-generation-web/src/plugin.ts
@@ -3,7 +3,8 @@ import {
   ActionRegistry,
   Output,
   initializeProviders,
-  registerDockComponent
+  registerDockComponent,
+  checkAiPluginVersion
 } from '@imgly/plugin-ai-generation-web';
 import { PluginConfiguration } from './types';
 import { toArray } from '@imgly/plugin-utils';
@@ -20,6 +21,9 @@ export function AudioGeneration<I, O extends Output>(
   return {
     async initialize({ cesdk }) {
       if (cesdk == null) return;
+
+      // Check AI plugin version consistency
+      checkAiPluginVersion(cesdk, PLUGIN_ID, PLUGIN_VERSION);
 
       cesdk.setTranslations({
         en: {

--- a/packages/plugin-ai-generation-web/src/index.ts
+++ b/packages/plugin-ai-generation-web/src/index.ts
@@ -61,6 +61,8 @@ export {
   addIconSetOnce
 } from './utils/utils';
 
+export { checkAiPluginVersion } from './utils/checkAiPluginVersion';
+
 export { default as registerDockComponent } from './ui/components/registerDockComponent';
 
 export { default as enableQuickActionForImageFill } from './ui/quickActions/enableImageFill';

--- a/packages/plugin-ai-generation-web/src/utils/checkAiPluginVersion.ts
+++ b/packages/plugin-ai-generation-web/src/utils/checkAiPluginVersion.ts
@@ -1,0 +1,61 @@
+import type CreativeEditorSDK from '@cesdk/cesdk-js';
+
+/**
+ * Checks if the current AI plugin version matches the shared version across all AI plugins.
+ * Issues a console warning if versions don't match.
+ *
+ * @param cesdk - The CreativeEditorSDK instance
+ * @param pluginId - The ID of the current plugin
+ * @param currentVersion - The version of the current plugin
+ */
+export function checkAiPluginVersion(
+  cesdk: CreativeEditorSDK,
+  pluginId: string,
+  currentVersion: string
+): void {
+  const AI_PLUGIN_VERSION_KEY = 'ai-plugin-version';
+  const AI_PLUGIN_VERSION_WARNING_KEY = 'ai-plugin-version-warning-shown';
+
+  try {
+    const sharedVersion = cesdk.ui.experimental.getGlobalStateValue<string>(
+      AI_PLUGIN_VERSION_KEY
+    );
+
+    if (!sharedVersion) {
+      // First AI plugin sets the shared version
+      cesdk.ui.experimental.setGlobalStateValue(
+        AI_PLUGIN_VERSION_KEY,
+        currentVersion
+      );
+    } else if (sharedVersion !== currentVersion) {
+      // Version mismatch detected
+      const warningShown = cesdk.ui.experimental.getGlobalStateValue<boolean>(
+        AI_PLUGIN_VERSION_WARNING_KEY,
+        false
+      );
+
+      if (!warningShown) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[IMG.LY AI Plugins] Version mismatch detected!\n` +
+            `Plugin "${pluginId}" is using version ${currentVersion}, but other AI plugins are using version ${sharedVersion}.\n` +
+            `This may cause compatibility issues. Please ensure all AI plugins (@imgly/plugin-ai-*) use the same version.\n` +
+            `Consider updating all AI plugins to the same version for optimal compatibility.`
+        );
+
+        // Set flag to prevent duplicate warnings
+        cesdk.ui.experimental.setGlobalStateValue(
+          AI_PLUGIN_VERSION_WARNING_KEY,
+          true
+        );
+      }
+    }
+  } catch (error) {
+    // Fail silently if global state access fails
+    // eslint-disable-next-line no-console
+    console.debug(
+      '[IMG.LY AI Plugins] Could not check plugin version consistency:',
+      error
+    );
+  }
+}

--- a/packages/plugin-ai-image-generation-web/src/plugin.ts
+++ b/packages/plugin-ai-image-generation-web/src/plugin.ts
@@ -5,7 +5,8 @@ import {
   registerDockComponent,
   ActionRegistry,
   initializeQuickActionComponents,
-  AI_EDIT_MODE
+  AI_EDIT_MODE,
+  checkAiPluginVersion
 } from '@imgly/plugin-ai-generation-web';
 import { PluginConfiguration } from './types';
 import iconSprite, { PLUGIN_ICON_SET_ID } from './iconSprite';
@@ -31,6 +32,10 @@ export function ImageGeneration<I, O extends Output>(
   return {
     async initialize({ cesdk }) {
       if (cesdk == null) return;
+
+      // Check AI plugin version consistency
+      checkAiPluginVersion(cesdk, PLUGIN_ID, PLUGIN_VERSION);
+
       const registry = ActionRegistry.get();
 
       const disposeApp = registry.register({

--- a/packages/plugin-ai-text-generation-web/src/plugin.ts
+++ b/packages/plugin-ai-text-generation-web/src/plugin.ts
@@ -6,7 +6,8 @@ import {
   Output,
   ActionRegistry,
   initializeQuickActionComponents,
-  AI_EDIT_MODE
+  AI_EDIT_MODE,
+  checkAiPluginVersion
 } from '@imgly/plugin-ai-generation-web';
 import { toArray } from '@imgly/plugin-utils';
 import Improve from './quickActions/Improve';
@@ -16,6 +17,7 @@ import Longer from './quickActions/Longer';
 import ChangeTone from './quickActions/ChangeTone';
 import Translate from './quickActions/Translate';
 import ChangeTextTo from './quickActions/ChangeTextTo';
+import { PLUGIN_ID } from './constants';
 
 export { PLUGIN_ID } from './constants';
 
@@ -25,6 +27,9 @@ export function TextGeneration<I, O extends Output>(
   return {
     async initialize({ cesdk }) {
       if (cesdk == null) return;
+
+      // Check AI plugin version consistency
+      checkAiPluginVersion(cesdk, PLUGIN_ID, PLUGIN_VERSION);
 
       cesdk.ui.addIconSet(PLUGIN_ICON_SET_ID, iconSprite);
       cesdk.i18n.setTranslations({

--- a/packages/plugin-ai-video-generation-web/src/plugin.ts
+++ b/packages/plugin-ai-video-generation-web/src/plugin.ts
@@ -3,7 +3,8 @@ import {
   ActionRegistry,
   initializeProviders,
   Output,
-  registerDockComponent
+  registerDockComponent,
+  checkAiPluginVersion
 } from '@imgly/plugin-ai-generation-web';
 import { PluginConfiguration } from './types';
 import { toArray } from '@imgly/plugin-utils';
@@ -20,6 +21,9 @@ export function VideoGeneration<I, O extends Output>(
   return {
     async initialize({ cesdk }) {
       if (cesdk == null) return;
+
+      // Check AI plugin version consistency
+      checkAiPluginVersion(cesdk, PLUGIN_ID, PLUGIN_VERSION);
 
       cesdk.setTranslations({
         en: {


### PR DESCRIPTION
- Add checkAiPluginVersion utility to detect version mismatches at runtime
- Integrate version checking into all AI plugin initialization flows
- Uses CE.SDK global state to track shared version across plugins
- Display console warning when different AI plugin versions are detected
- Warning shown only once per session to prevent spam
- Graceful fallback if global state access fails