### PR TITLE
Use old `middleware` configuration if `middlewares` is not defined

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -17,6 +17,10 @@
 -   [image-generation] **Recraft20b Provider**: Added new Recraft20b (v2) provider via fal.ai with support for icon styles including `broken_line`, `colored_outline`, `colored_shapes`, and more
 -   [sticker-generation] **New Sticker Generation Plugin**: Added `@imgly/plugin-ai-sticker-generation-web` plugin for AI-powered sticker generation with support for text-to-sticker generation using Recraft20b provider with icon styles
 
+### Deprecated Features
+
+-   [all] **Middleware Configuration**: The `middleware` property in provider configurations is deprecated. Use `middlewares` instead. The old property will continue to work for now.
+
 ## [0.1.10] - 2025-06-20
 
 -   [all] Fix issue with GPT provider when using text provider

--- a/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenMultilingualV2.ts
+++ b/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenMultilingualV2.ts
@@ -160,7 +160,7 @@ function getProvider(
     output: {
       abortable: true,
       history: '@imgly/indexedDB',
-      middleware: config.middlewares,
+      middleware: config.middlewares ?? config.middleware ?? [],
       generate: async (
         input: ElevenlabsInput,
         { abortSignal }: { abortSignal?: AbortSignal }

--- a/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenSoundEffects.ts
+++ b/packages/plugin-ai-audio-generation-web/src/elevenlabs/ElevenSoundEffects.ts
@@ -64,7 +64,7 @@ function getProvider(
     output: {
       abortable: true,
       history: '@imgly/indexedDB',
-      middleware: config.middlewares,
+      middleware: config.middlewares ?? config.middleware ?? [],
       generate: async (
         input: ElevenlabsInput,
         { abortSignal }: { abortSignal?: AbortSignal }

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/GeminiFlashEdit.ts
@@ -83,7 +83,7 @@ function getProvider(
           })
         }
       },
-      middleware: config.middlewares,
+      middleware: config.middlewares ?? config.middleware ?? [],
       headers: config.headers,
       getBlockInput: async (input) => {
         const { width, height } = await getImageDimensionsFromURL(

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/Recraft20b.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/Recraft20b.ts
@@ -182,7 +182,7 @@ function getProvider(
       // @ts-ignore
       schema: Recraft20bSchema,
       inputReference: '#/components/schemas/Recraft20bInput',
-      middleware: config.middlewares ?? [],
+      middleware: config.middlewares ?? config.middleware ?? [],
       headers: config.headers,
       userFlow: 'placeholder',
       renderCustomProperty: {

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/RecraftV3.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/RecraftV3.ts
@@ -146,7 +146,7 @@ function getProvider(
       // @ts-ignore
       schema: RecraftV3Schema,
       inputReference: '#/components/schemas/RecraftV3Input',
-      middleware: config.middlewares ?? [],
+      middleware: config.middlewares ?? config.middleware ?? [],
       headers: config.headers,
       userFlow: 'placeholder',
       renderCustomProperty: {

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/createImageProvider.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/createImageProvider.ts
@@ -16,6 +16,11 @@ import { ImageQuickActionSupportMap } from '../types';
 type ImageProviderConfiguration = {
   proxyUrl: string;
   debug?: boolean;
+  middlewares?: Middleware<any, any>[];
+  /**
+   * @deprecated Use `middlewares` instead.
+   */
+  middleware?: Middleware<any, any>[];
 };
 
 /**
@@ -47,7 +52,8 @@ function createImageProvider<I extends Record<string, any>>(
   },
   config: ImageProviderConfiguration
 ): Provider<'image', I, { kind: 'image'; url: string }> {
-  const middleware = options.middleware ?? [];
+  const middleware =
+    options.middleware ?? config.middlewares ?? config.middleware ?? [];
   const provider: Provider<'image', I, ImageOutput> = {
     id: options.modelKey,
     kind: 'image',

--- a/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
+++ b/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.image2image.ts
@@ -144,7 +144,7 @@ function getProvider(
     output: {
       abortable: true,
       history: '@imgly/indexedDB',
-      middleware: config.middlewares ?? [],
+      middleware: config.middlewares ?? config.middleware ?? [],
       generate: async (
         input: GptImage1Input,
         { abortSignal }: { abortSignal?: AbortSignal }

--- a/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.text2image.ts
+++ b/packages/plugin-ai-image-generation-web/src/open-ai/GptImage1.text2image.ts
@@ -165,7 +165,7 @@ function getProvider(
     output: {
       abortable: true,
       history: '@imgly/indexedDB',
-      middleware: config.middlewares ?? [],
+      middleware: config.middlewares ?? config.middleware ?? [],
       generate: async (
         input: GptImage1Input,
         { abortSignal }: { abortSignal?: AbortSignal }

--- a/packages/plugin-ai-sticker-generation-web/src/fal-ai/Recraft20b.ts
+++ b/packages/plugin-ai-sticker-generation-web/src/fal-ai/Recraft20b.ts
@@ -121,7 +121,7 @@ function getProvider(
       // @ts-ignore
       schema: Recraft20bSchema,
       inputReference: '#/components/schemas/Recraft20bInput',
-      middleware: config.middlewares ?? [],
+      middleware: config.middlewares ?? config.middleware ?? [],
       headers: config.headers,
       userFlow: 'placeholder',
       renderCustomProperty: {

--- a/packages/plugin-ai-sticker-generation-web/src/fal-ai/createStickerProvider.ts
+++ b/packages/plugin-ai-sticker-generation-web/src/fal-ai/createStickerProvider.ts
@@ -2,7 +2,8 @@ import { type OpenAPIV3 } from 'openapi-types';
 import CreativeEditorSDK, { CreativeEngine } from '@cesdk/cesdk-js';
 import {
   RenderCustomProperty,
-  CommonProperties
+  CommonProperties,
+  Middleware
 } from '@imgly/plugin-ai-generation-web';
 import { fal } from '@fal-ai/client';
 import { isCustomImageSize, uploadImageInputToFalIfNeeded } from './utils';
@@ -12,6 +13,11 @@ import { StickerQuickActionSupportMap } from '../types';
 type StickerProviderConfiguration = {
   proxyUrl: string;
   debug?: boolean;
+  middlewares?: Middleware<any, any>[];
+  /**
+   * @deprecated Use `middlewares` instead.
+   */
+  middleware?: Middleware<any, any>[];
 };
 
 /**
@@ -44,7 +50,8 @@ function createStickerProvider<I extends Record<string, any>>(
   },
   config: StickerProviderConfiguration
 ): any {
-  const middleware = options.middleware ?? [];
+  const middleware =
+    options.middleware ?? config.middlewares ?? config.middleware ?? [];
   const provider: any = {
     id: options.modelKey,
     kind: 'sticker',

--- a/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
+++ b/packages/plugin-ai-text-generation-web/src/anthropic/AnthropicProvider.ts
@@ -65,7 +65,7 @@ export function AnthropicProvider(
         }
       },
       output: {
-        middleware: config.middlewares,
+        middleware: config.middlewares ?? config.middleware ?? [],
         generate: async (
           { prompt, blockId },
           { engine, abortSignal }

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01Live.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01Live.ts
@@ -34,7 +34,7 @@ function getProvider(
       inputReference: '#/components/schemas/MinimaxVideo01LiveInput',
 
       headers: config.headers,
-      middleware: config.middlewares,
+      middleware: config.middlewares ?? config.middleware ?? [],
       cesdk,
       getBlockInput: () => {
         return Promise.resolve({

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/MinimaxVideo01LiveImageToVideo.ts
@@ -59,7 +59,7 @@ function getProvider(
         '#/components/schemas/MinimaxVideo01LiveImageToVideoInput',
       cesdk,
       headers: config.headers,
-      middleware: config.middlewares,
+      middleware: config.middlewares ?? config.middleware ?? [],
       supportedQuickActions: {
         'ly.img.createVideo': {
           mapInput: () => {

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/PixverseV35TextToVideo.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/PixverseV35TextToVideo.ts
@@ -59,7 +59,7 @@ function getProvider(
       cesdk,
 
       headers: config.headers,
-      middleware: config.middlewares,
+      middleware: config.middlewares ?? config.middleware ?? [],
       getBlockInput: (input) => {
         if (input.aspect_ratio != null && input.resolution != null) {
           const [widthRatio, heightRatio] = input.aspect_ratio

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/createVideoProvider.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/createVideoProvider.ts
@@ -15,6 +15,11 @@ import { VideoQuickActionSupportMap } from '../types';
 type VideoProviderConfiguration = {
   proxyUrl: string;
   debug?: boolean;
+  middlewares?: Middleware<any, any>[];
+  /**
+   * @deprecated Use `middlewares` instead.
+   */
+  middleware?: Middleware<any, any>[];
 };
 
 /**
@@ -48,7 +53,8 @@ function createVideoProvider<I extends Record<string, any>>(
   },
   config: VideoProviderConfiguration
 ): Provider<'video', I, { kind: 'video'; url: string }> {
-  const middleware = options.middleware ?? [];
+  const middleware =
+    options.middleware ?? config.middlewares ?? config.middleware ?? [];
 
   const provider: Provider<'video', I, VideoOutput> = {
     id: options.modelKey,


### PR DESCRIPTION
(making it backwards compatible)