### PR TITLE
Update dependencies for background removal plugin

### DIFF
--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -26,7 +26,7 @@
     "@imgly/plugin-qr-code-web": "workspace:*",
     "@imgly/plugin-remote-asset-source-web": "workspace:*",
     "@imgly/plugin-vectorizer-web": "workspace:*",
-    "onnxruntime-web": "1.21.0-dev.20250206-d981b153d3",
+    "onnxruntime-web": "1.21.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.3.0"

--- a/packages/plugin-background-removal-web/CHANGELOG.md
+++ b/packages/plugin-background-removal-web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version v1.2.0
+
+- Updates dependency `@imgly/background-removal` to 1.7.0
+
 ## Version v0.3.0
 
 - Adds background removal provider configuration

--- a/packages/plugin-background-removal-web/package.json
+++ b/packages/plugin-background-removal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgly/plugin-background-removal-web",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Background Removal plugin for the CE.SDK editor",
   "keywords": [
     "CE.SDK",
@@ -79,9 +79,9 @@
   },
   "peerDependencies": {
     "@cesdk/cesdk-js": "^1.32.0",
-    "onnxruntime-web": "1.21.0-dev.20250206-d981b153d3"
+    "onnxruntime-web": "1.21.0"
   },
   "dependencies": {
-    "@imgly/background-removal": "1.6.0"
+    "@imgly/background-removal": "1.7.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,7 +158,7 @@ importers:
         version: file:packages/plugin-ai-video-generation-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))
       '@imgly/plugin-background-removal-web':
         specifier: workspace:*
-        version: file:packages/plugin-background-removal-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))(onnxruntime-web@1.21.0-dev.20250206-d981b153d3)
+        version: file:packages/plugin-background-removal-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))(onnxruntime-web@1.21.0)
       '@imgly/plugin-cutout-library-web':
         specifier: workspace:*
         version: file:packages/plugin-cutout-library-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))
@@ -175,8 +175,8 @@ importers:
         specifier: workspace:*
         version: file:packages/plugin-vectorizer-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))
       onnxruntime-web:
-        specifier: 1.21.0-dev.20250206-d981b153d3
-        version: 1.21.0-dev.20250206-d981b153d3
+        specifier: 1.21.0
+        version: 1.21.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -564,11 +564,11 @@ importers:
   packages/plugin-background-removal-web:
     dependencies:
       '@imgly/background-removal':
-        specifier: 1.6.0
-        version: 1.6.0(onnxruntime-web@1.21.0-dev.20250206-d981b153d3)
+        specifier: 1.7.0
+        version: 1.7.0(onnxruntime-web@1.21.0)
       onnxruntime-web:
-        specifier: 1.21.0-dev.20250206-d981b153d3
-        version: 1.21.0-dev.20250206-d981b153d3
+        specifier: 1.21.0
+        version: 1.21.0
     dependenciesMeta:
       '@imgly/plugin-utils':
         injected: true
@@ -1317,11 +1317,10 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@imgly/background-removal@1.6.0':
-    resolution: {integrity: sha512-nmqOBDE9dQpDEJg73XrKNUoWugyyDHEVh+U1akjYdUW85ILh9UilvKu/kdv1MI822rKExwgLNuVLVulzAzgZJg==}
+  '@imgly/background-removal@1.7.0':
+    resolution: {integrity: sha512-/1ZryrMYg2ckIvJKoTu5Np50JfYMVffDMlVmppw/BdbN3pBTN7e6stI5/7E/LVh9DDzz6J588s7sWqul3fy5wA==}
     peerDependencies:
-      onnxruntime-web: 1.21.0-dev.20250206-d981b153d3
-    bundledDependencies: []
+      onnxruntime-web: 1.21.0
 
   '@imgly/plugin-ai-apps-web@file:packages/plugin-ai-apps-web':
     resolution: {directory: packages/plugin-ai-apps-web, type: directory}
@@ -1362,7 +1361,7 @@ packages:
     resolution: {directory: packages/plugin-background-removal-web, type: directory}
     peerDependencies:
       '@cesdk/cesdk-js': ^1.32.0
-      onnxruntime-web: 1.21.0-dev.20250206-d981b153d3
+      onnxruntime-web: 1.21.0
 
   '@imgly/plugin-cutout-library-web@file:packages/plugin-cutout-library-web':
     resolution: {directory: packages/plugin-cutout-library-web, type: directory}
@@ -3617,11 +3616,11 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  onnxruntime-common@1.21.0-dev.20250206-d981b153d3:
-    resolution: {integrity: sha512-TwaE51xV9q2y8pM61q73rbywJnusw9ivTEHAJ39GVWNZqxCoDBpe/tQkh/w9S+o/g+zS7YeeL0I/2mEWd+dgyA==}
+  onnxruntime-common@1.21.0:
+    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
 
-  onnxruntime-web@1.21.0-dev.20250206-d981b153d3:
-    resolution: {integrity: sha512-esDVQdRic6J44VBMFLumYvcGfioMh80ceLmzF1yheJyuLKq/Th8VT2aj42XWQst+2bcWnAhw4IKmRQaqzU8ugg==}
+  onnxruntime-web@1.21.0:
+    resolution: {integrity: sha512-adzOe+7uI7lKz6pQNbAsLMQd2Fq5Jhmoxd8LZjJr8m3KvbFyiYyRxRiC57/XXD+jb18voppjeGAjoZmskXG+7A==}
 
   openai@4.104.0:
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
@@ -5016,11 +5015,11 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@imgly/background-removal@1.6.0(onnxruntime-web@1.21.0-dev.20250206-d981b153d3)':
+  '@imgly/background-removal@1.7.0(onnxruntime-web@1.21.0)':
     dependencies:
       lodash-es: 4.17.21
       ndarray: 1.0.19
-      onnxruntime-web: 1.21.0-dev.20250206-d981b153d3
+      onnxruntime-web: 1.21.0
       zod: 3.24.2
 
   '@imgly/plugin-ai-apps-web@file:packages/plugin-ai-apps-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))':
@@ -5059,11 +5058,11 @@ snapshots:
     dependencies:
       '@cesdk/cesdk-js': 1.49.1(react@18.3.1)
 
-  '@imgly/plugin-background-removal-web@file:packages/plugin-background-removal-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))(onnxruntime-web@1.21.0-dev.20250206-d981b153d3)':
+  '@imgly/plugin-background-removal-web@file:packages/plugin-background-removal-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))(onnxruntime-web@1.21.0)':
     dependencies:
       '@cesdk/cesdk-js': 1.49.1(react@18.3.1)
-      '@imgly/background-removal': 1.6.0(onnxruntime-web@1.21.0-dev.20250206-d981b153d3)
-      onnxruntime-web: 1.21.0-dev.20250206-d981b153d3
+      '@imgly/background-removal': 1.7.0(onnxruntime-web@1.21.0)
+      onnxruntime-web: 1.21.0
 
   '@imgly/plugin-cutout-library-web@file:packages/plugin-cutout-library-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))':
     dependencies:
@@ -7964,14 +7963,14 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onnxruntime-common@1.21.0-dev.20250206-d981b153d3: {}
+  onnxruntime-common@1.21.0: {}
 
-  onnxruntime-web@1.21.0-dev.20250206-d981b153d3:
+  onnxruntime-web@1.21.0:
     dependencies:
       flatbuffers: 25.2.10
       guid-typescript: 1.0.9
       long: 5.3.1
-      onnxruntime-common: 1.21.0-dev.20250206-d981b153d3
+      onnxruntime-common: 1.21.0
       platform: 1.3.6
       protobufjs: 7.4.0
 


### PR DESCRIPTION
Upgrade `onnxruntime-web` to version 1.21.0 and `@imgly/background-removal` to version 1.7.0, along with updating the plugin version to 1.2.0. 
This makes use of a stable onnx runtime version instead of a dev tag