### PR TITLE
AI Plugins: Propagate lock Config from Quick Action

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -4,6 +4,7 @@
 
 -   [all] **Automatic History Asset Library Entries**: Composite history asset sources now automatically have corresponding asset library entries created with the same IDs (e.g., `ly.img.ai.image-generation.history`)
 -   [all] **Provider Selection in Expanded Quick Actions**: When a quick action is expanded, users can now switch between all providers that support that specific quick action, enhancing flexibility in provider selection
+-   [all] **Quick Action Can Disable Lock**: Some quick actions can now decide to not lock the block when operating on a block. Examples are `CreateVariant` and `CombineImages`.
 
 ## [0.2.2] - 2025-07-16
 

--- a/packages/plugin-ai-generation-web/src/ui/quickActions/createQuickActionMenuRenderFunction.ts
+++ b/packages/plugin-ai-generation-web/src/ui/quickActions/createQuickActionMenuRenderFunction.ts
@@ -360,6 +360,8 @@ function createQuickActionMenuRenderFunction<
                     expandedQuickAction.definition.defaults?.confirmation ??
                     true,
 
+                  lock: expandedQuickAction.definition.defaults?.lock ?? true,
+
                   close,
                   cesdk: context.cesdk,
                   debug: context.debug,


### PR DESCRIPTION
**Quick Action Can Disable Lock**: Some quick actions can now decide to not lock the block when operating on a block. Examples are `CreateVariant` and `CombineImages`.