### PR TITLE
Fix fal.ai singleton configuration conflict

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -7,6 +7,11 @@
 -   [image-generation] **NanoBanana Provider**: Added NanoBanana text-to-image provider via fal.ai with fast generation times, 1024×1024 resolution, support for multiple output formats (JPEG, PNG), configurable number of images (1-4), and remixPageWithPrompt quick action
 -   [image-generation] **NanoBananaEdit Provider**: Added NanoBananaEdit image-to-image provider via fal.ai for editing existing images with text prompts, supporting all standard quick actions (editImage, swapBackground, styleTransfer, artistTransfer, createVariant, combineImages with up to 10 images, remixPage, remixPageWithPrompt)
 
+### Bug Fixes
+
+-   [all] **fal.ai Provider Configuration**: Fixed singleton configuration conflict when using multiple fal.ai providers with different proxy URLs. Each provider now maintains its own client instance instead of overwriting a global configuration
+-   [video-generation] **Missing Dependency**: Added missing `@fal-ai/client` dependency to plugin-ai-video-generation-web package.json to ensure the package works correctly when installed independently
+
 ## [0.2.4] - 2025-08-07
 
 ### New Features

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/createFalClient.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/createFalClient.ts
@@ -1,0 +1,26 @@
+import {
+  createFalClient as createClient,
+  type FalClient as FalClientType
+} from '@fal-ai/client';
+
+export type FalClient = FalClientType;
+
+export function createFalClient(
+  proxyUrl: string,
+  headers?: Record<string, string>
+): FalClient {
+  const client = createClient({
+    proxyUrl,
+    requestMiddleware: async (request) => {
+      return {
+        ...request,
+        headers: {
+          ...request.headers,
+          ...(headers ?? {})
+        }
+      };
+    }
+  });
+
+  return client;
+}

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/utils.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/utils.ts
@@ -1,6 +1,6 @@
-import { fal } from '@fal-ai/client';
 import { mimeTypeToExtension } from '@imgly/plugin-utils';
 import CreativeEditorSDK from '@cesdk/cesdk-js';
+import { FalClient } from './createFalClient';
 
 type CustomImageSize = {
   width: number;
@@ -19,6 +19,7 @@ export function isCustomImageSize(
 }
 
 export async function uploadImageInputToFalIfNeeded(
+  client: FalClient,
   imageUrl?: string,
   cesdk?: CreativeEditorSDK
 ): Promise<string | undefined> {
@@ -37,7 +38,7 @@ export async function uploadImageInputToFalIfNeeded(
         type: mimeType
       }
     );
-    return fal.storage.upload(imageUrlFile);
+    return client.storage.upload(imageUrlFile);
   }
   if (cesdk != null && imageUrl.startsWith('buffer:')) {
     const mimeType = await cesdk.engine.editor.getMimeType(imageUrl);
@@ -52,20 +53,21 @@ export async function uploadImageInputToFalIfNeeded(
         type: mimeType
       }
     );
-    return fal.storage.upload(imageUrlFile);
+    return client.storage.upload(imageUrlFile);
   }
 
   return imageUrl;
 }
 
 export async function uploadImageArrayToFalIfNeeded(
+  client: FalClient,
   imageUrls?: string[],
   cesdk?: CreativeEditorSDK
 ): Promise<string[] | undefined> {
   if (imageUrls == null || !Array.isArray(imageUrls)) return undefined;
 
   const uploadedUrls = await Promise.all(
-    imageUrls.map((url) => uploadImageInputToFalIfNeeded(url, cesdk))
+    imageUrls.map((url) => uploadImageInputToFalIfNeeded(client, url, cesdk))
   );
 
   return uploadedUrls.filter((url): url is string => url != null);

--- a/packages/plugin-ai-sticker-generation-web/src/fal-ai/createFalClient.ts
+++ b/packages/plugin-ai-sticker-generation-web/src/fal-ai/createFalClient.ts
@@ -1,0 +1,26 @@
+import {
+  createFalClient as createClient,
+  type FalClient as FalClientType
+} from '@fal-ai/client';
+
+export type FalClient = FalClientType;
+
+export function createFalClient(
+  proxyUrl: string,
+  headers?: Record<string, string>
+): FalClient {
+  const client = createClient({
+    proxyUrl,
+    requestMiddleware: async (request) => {
+      return {
+        ...request,
+        headers: {
+          ...request.headers,
+          ...(headers ?? {})
+        }
+      };
+    }
+  });
+
+  return client;
+}

--- a/packages/plugin-ai-sticker-generation-web/src/fal-ai/utils.ts
+++ b/packages/plugin-ai-sticker-generation-web/src/fal-ai/utils.ts
@@ -1,6 +1,6 @@
-import { fal } from '@fal-ai/client';
 import { mimeTypeToExtension } from '@imgly/plugin-utils';
 import CreativeEditorSDK from '@cesdk/cesdk-js';
+import { FalClient } from './createFalClient';
 
 type CustomImageSize = {
   width: number;
@@ -19,6 +19,7 @@ export function isCustomImageSize(
 }
 
 export async function uploadImageInputToFalIfNeeded(
+  client: FalClient,
   imageUrl?: string,
   cesdk?: CreativeEditorSDK
 ): Promise<string | undefined> {
@@ -37,7 +38,7 @@ export async function uploadImageInputToFalIfNeeded(
         type: mimeType
       }
     );
-    return fal.storage.upload(imageUrlFile);
+    return client.storage.upload(imageUrlFile);
   }
   if (cesdk != null && imageUrl.startsWith('buffer:')) {
     const mimeType = await cesdk.engine.editor.getMimeType(imageUrl);
@@ -52,7 +53,7 @@ export async function uploadImageInputToFalIfNeeded(
         type: mimeType
       }
     );
-    return fal.storage.upload(imageUrlFile);
+    return client.storage.upload(imageUrlFile);
   }
 
   return imageUrl;

--- a/packages/plugin-ai-video-generation-web/package.json
+++ b/packages/plugin-ai-video-generation-web/package.json
@@ -50,6 +50,7 @@
     "_syncPnpm": "pnpm sync-dependencies-meta-injected"
   },
   "devDependencies": {
+    "@fal-ai/client": "^1.3.0",
     "@imgly/plugin-utils": "workspace:*",
     "@imgly/plugin-ai-generation-web": "workspace:*",
     "@types/ndarray": "^1.0.14",

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/createFalClient.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/createFalClient.ts
@@ -1,0 +1,26 @@
+import {
+  createFalClient as createClient,
+  type FalClient as FalClientType
+} from '@fal-ai/client';
+
+export type FalClient = FalClientType;
+
+export function createFalClient(
+  proxyUrl: string,
+  headers?: Record<string, string>
+): FalClient {
+  const client = createClient({
+    proxyUrl,
+    requestMiddleware: async (request) => {
+      return {
+        ...request,
+        headers: {
+          ...request.headers,
+          ...(headers ?? {})
+        }
+      };
+    }
+  });
+
+  return client;
+}

--- a/packages/plugin-ai-video-generation-web/src/fal-ai/utils.ts
+++ b/packages/plugin-ai-video-generation-web/src/fal-ai/utils.ts
@@ -1,7 +1,8 @@
-import { fal } from '@fal-ai/client';
 import CreativeEditorSDK from '@cesdk/cesdk-js';
+import { FalClient } from './createFalClient';
 
 export async function uploadImageInputToFalIfNeeded(
+  client: FalClient,
   imageUrl?: string,
   cesdk?: CreativeEditorSDK
 ): Promise<string | undefined> {
@@ -12,7 +13,7 @@ export async function uploadImageInputToFalIfNeeded(
     const imageUrlFile = new File([imageUrlBlob], 'image.png', {
       type: 'image/png'
     });
-    return fal.storage.upload(imageUrlFile);
+    return client.storage.upload(imageUrlFile);
   }
   if (cesdk != null && imageUrl.startsWith('buffer:')) {
     const mimeType = await cesdk.engine.editor.getMimeType(imageUrl);
@@ -23,7 +24,7 @@ export async function uploadImageInputToFalIfNeeded(
     const imageUrlFile = new File([buffer], 'image.png', {
       type: mimeType
     });
-    return fal.storage.upload(imageUrlFile);
+    return client.storage.upload(imageUrlFile);
   }
 
   return imageUrl;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,7 +538,7 @@ importers:
     devDependencies:
       '@fal-ai/client':
         specifier: ^1.3.0
-        version: 1.3.0
+        version: 1.6.2
       '@imgly/plugin-ai-generation-web':
         specifier: workspace:*
         version: file:packages/plugin-ai-generation-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
       '@imgly/plugin-utils':
         injected: true
     devDependencies:
+      '@fal-ai/client':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@imgly/plugin-ai-generation-web':
         specifier: workspace:*
         version: file:packages/plugin-ai-generation-web(@cesdk/cesdk-js@1.49.1(react@18.3.1))


### PR DESCRIPTION
## Summary
- Resolve fal.ai singleton configuration conflict when using multiple providers with different proxy URLs
- Add missing @fal-ai/client dependency to video generation plugin

## Problem
The fal.ai library uses a singleton instance that is configured globally via `fal.config()`. When multiple fal.ai providers were initialized with different proxy URLs, each provider's `initialize` function would call `fal.config()`, overwriting the previous configuration. This caused all providers to use the proxy URL of the last initialized provider.

Additionally, the video generation plugin was missing the `@fal-ai/client` dependency in its package.json, relying on workspace hoisting.

## Solution
1. **Per-provider client instances**: Created a `createFalClient` factory function that returns configured fal client instances. Each provider now maintains its own client with its specific proxy URL and headers.

2. **Updated all fal.ai providers**: Modified `createImageProvider`, `createVideoProvider`, and `createStickerProvider` to use client instances instead of the global singleton.

3. **Fixed missing dependency**: Added `@fal-ai/client` to the video generation plugin's package.json.

## Changes
- Add `createFalClient.ts` factory function to each fal.ai plugin package
- Update provider creators to use client instances 
- Modify utility functions to accept client parameter for file uploads
- Remove singleton `fal.config()` calls from provider initialization
- Add missing dependency to video plugin

## Test Plan
- [x] Build all AI plugins with `pnpm --filter "@imgly/plugin-ai-*" build`
- [x] Run type checks with `pnpm --filter "@imgly/plugin-ai-*" check:types`
- [x] Test with demo app using multiple fal.ai providers
- [x] Verify each provider uses its configured proxy URL