### PR TITLE
feat(ai-image-generation): add ByteDance Seedream V4 providers

### DIFF
--- a/.claude/FAL-AI-INTEGRATION.md
+++ b/.claude/FAL-AI-INTEGRATION.md
@@ -63,7 +63,7 @@ The router outputs: `ROUTE_TO_AGENT: {agent-name}`
 IMMEDIATELY use Task tool with:
 - subagent_type: "pnpm-workflow-fixer"
 - description: "Fix integration"
-- prompt: "Verify and fix integration for [EXACT_MODEL_NAME]. Ensure provider is added to index.ts and ai-demo.tsx. Run pnpm build to verify."
+- prompt: "Verify and fix integration for [EXACT_MODEL_NAME]. Ensure provider is added to index.ts and examples/ai/src/App.tsx. Run pnpm build to verify."
 ```
 
 ⚠️ **CRITICAL**: Even if you don't see the ROUTE_TO_AGENT output clearly, ALWAYS run pnpm-workflow-fixer after the generator completes. This is NON-NEGOTIABLE.
@@ -90,7 +90,7 @@ You IMMEDIATELY:
 
 The pnpm-workflow-fixer will automatically:
 - Add provider to `/src/fal-ai/index.ts` exports
-- Add provider to `ai-demo.tsx` with proper middleware
+- Add provider to `examples/ai/src/App.tsx` with proper middleware
 - Run `pnpm build` to verify no errors
 - Fix any integration issues found
 

--- a/.claude/GENERIC-PROVIDER-INTEGRATION.md
+++ b/.claude/GENERIC-PROVIDER-INTEGRATION.md
@@ -356,7 +356,7 @@ src/
 
 3. **Add to Demo**
    ```typescript
-   // In ai-demo.tsx appropriate category
+   // In examples/ai/src/App.tsx appropriate category
    {Provider}{MediaType}.{Model}.{Type}({
      middleware: [{type}RateLimitMiddleware, errorMiddleware],
      proxyUrl: import.meta.env.VITE_{PROVIDER}_PROXY_URL,

--- a/.claude/agents/fal-ai/fal-ai-provider-generator-i2i.md
+++ b/.claude/agents/fal-ai/fal-ai-provider-generator-i2i.md
@@ -210,7 +210,7 @@ After user approval, generate exactly these 5 files/updates:
 After generating files:
 1. Place files in `/packages/plugin-ai-image-generation-web/src/fal-ai/` directory
 2. Add export to `/packages/plugin-ai-image-generation-web/src/fal-ai/index.ts`
-3. **MANDATORY**: Add the new provider to the AI demo in `@examples/web/src/pages/ai-demo.tsx` in the `image2image` provider section with proper middleware configuration
+3. **MANDATORY**: Add the new provider to the AI demo in `@examples/ai/src/App.tsx` in the `image2image` provider section with proper middleware configuration
 4. Update `/packages/plugin-ai-image-generation-web/translations.json` with all UI property translations
 5. Update `/packages/plugin-ai-image-generation-web/README.md` with provider documentation
 6. Update `/CHANGELOG-AI.md` in the Unreleased section under New Features
@@ -260,7 +260,7 @@ ROUTE_TO_AGENT: pnpm-workflow-fixer
 
 This ensures automatic workflow continuation for integration validation and build checks. The pnpm-workflow-fixer will:
 - Verify the provider was added to index.ts
-- Ensure the provider is configured in ai-demo.tsx
+- Ensure the provider is configured in examples/ai/src/App.tsx
 - Run pnpm build to check for errors
 - Fix any integration issues
 

--- a/.claude/agents/fal-ai/fal-ai-provider-generator-i2v.md
+++ b/.claude/agents/fal-ai/fal-ai-provider-generator-i2v.md
@@ -210,7 +210,7 @@ After user approval, generate exactly these 5 files/updates:
 After generating files:
 1. Place files in `/packages/plugin-ai-video-generation-web/src/fal-ai/` directory
 2. Add export to `/packages/plugin-ai-video-generation-web/src/fal-ai/index.ts`
-3. **MANDATORY**: Add the new provider to the AI demo in `@examples/web/src/pages/ai-demo.tsx` in the `image2video` provider section with proper middleware configuration using `videoRateLimitMiddleware`
+3. **MANDATORY**: Add the new provider to the AI demo in `@examples/ai/src/App.tsx` in the `image2video` provider section with proper middleware configuration using `videoRateLimitMiddleware`
 4. Update `/packages/plugin-ai-video-generation-web/translations.json` with all UI property translations
 5. Update `/packages/plugin-ai-video-generation-web/README.md` with provider documentation
 6. Update `/CHANGELOG-AI.md` in the Unreleased section under New Features
@@ -276,7 +276,7 @@ ROUTE_TO_AGENT: pnpm-workflow-fixer
 
 This ensures automatic workflow continuation for integration validation and build checks. The pnpm-workflow-fixer will:
 - Verify the provider was added to index.ts
-- Ensure the provider is configured in ai-demo.tsx in the image2video section
+- Ensure the provider is configured in examples/ai/src/App.tsx in the image2video section
 - Run pnpm build to check for errors
 - Fix any integration issues
 

--- a/.claude/agents/fal-ai/fal-ai-provider-generator-t2i.md
+++ b/.claude/agents/fal-ai/fal-ai-provider-generator-t2i.md
@@ -140,7 +140,7 @@ After user approval, generate exactly these 5 files/updates:
 After generating files:
 1. Place files in `/packages/plugin-ai-image-generation-web/src/fal-ai/` directory
 2. Add export to `/packages/plugin-ai-image-generation-web/src/fal-ai/index.ts`
-3. **MANDATORY**: Add the new provider to the AI demo in `@examples/web/src/pages/ai-demo.tsx` in the text2image provider section with proper middleware configuration
+3. **MANDATORY**: Add the new provider to the AI demo in `@examples/ai/src/App.tsx` in the text2image provider section with proper middleware configuration
 4. Update `/packages/plugin-ai-image-generation-web/translations.json` with all UI property translations
 5. Update `/packages/plugin-ai-image-generation-web/README.md` with provider documentation
 6. Update `/CHANGELOG-AI.md` in the Unreleased section under New Features
@@ -181,7 +181,7 @@ ROUTE_TO_AGENT: pnpm-workflow-fixer
 
 This ensures automatic workflow continuation for integration validation and build checks. The pnpm-workflow-fixer will:
 - Verify the provider was added to index.ts
-- Ensure the provider is configured in ai-demo.tsx
+- Ensure the provider is configured in examples/ai/src/App.tsx
 - Run pnpm build to check for errors
 - Fix any integration issues
 

--- a/.claude/agents/fal-ai/fal-ai-provider-generator-t2v.md
+++ b/.claude/agents/fal-ai/fal-ai-provider-generator-t2v.md
@@ -157,7 +157,7 @@ After user approval, generate exactly these 5 files/updates:
 After generating files:
 1. Place files in `/packages/plugin-ai-video-generation-web/src/fal-ai/` directory (NOTE: different from image generation!)
 2. Add export to `/packages/plugin-ai-video-generation-web/src/fal-ai/index.ts`
-3. **MANDATORY**: Add the new provider to the AI demo in `@examples/web/src/pages/ai-demo.tsx` in the `text2video` provider section with proper middleware configuration using `videoRateLimitMiddleware`
+3. **MANDATORY**: Add the new provider to the AI demo in `@examples/ai/src/App.tsx` in the `text2video` provider section with proper middleware configuration using `videoRateLimitMiddleware`
 4. Update `/packages/plugin-ai-video-generation-web/translations.json` with all UI property translations
 5. Update `/packages/plugin-ai-video-generation-web/README.md` with provider documentation
 6. Update `/CHANGELOG-AI.md` in the Unreleased section under New Features
@@ -219,7 +219,7 @@ ROUTE_TO_AGENT: pnpm-workflow-fixer
 
 This ensures automatic workflow continuation for integration validation and build checks. The pnpm-workflow-fixer will:
 - Verify the provider was added to index.ts
-- Ensure the provider is configured in ai-demo.tsx in the text2video section
+- Ensure the provider is configured in examples/ai/src/App.tsx in the text2video section
 - Run pnpm build to check for errors
 - Fix any integration issues
 

--- a/.claude/agents/generic-provider/generic-provider-generator-i2i.md
+++ b/.claude/agents/generic-provider/generic-provider-generator-i2i.md
@@ -233,7 +233,7 @@ getActionConfig: (action) => {
    - Export in main plugin
 
 3. **Demo Integration**:
-   - Add to `image2image` section in ai-demo.tsx
+   - Add to `image2image` section in examples/ai/src/App.tsx
    - Configure with image rate limiting middleware
    - Set up environment variables
 

--- a/.claude/agents/generic-provider/generic-provider-generator-i2v.md
+++ b/.claude/agents/generic-provider/generic-provider-generator-i2v.md
@@ -288,7 +288,7 @@ async function prepareImageForAPI(imageUrl: string, requirements: any) {
    - Export in main plugin
 
 3. **Demo Integration**:
-   - Add to `image2video` section in ai-demo.tsx
+   - Add to `image2video` section in examples/ai/src/App.tsx
    - Configure with video rate limiting middleware
    - Set up environment variables
 

--- a/.claude/agents/generic-provider/generic-provider-generator-t2i.md
+++ b/.claude/agents/generic-provider/generic-provider-generator-t2i.md
@@ -160,7 +160,7 @@ export const {ModelName} = createImageProvider<{ModelName}Input>({
    - Export in main plugin index
 
 3. **Demo Integration**:
-   - Add provider to `examples/web/src/pages/ai-demo.tsx`
+   - Add provider to `examples/ai/src/App.tsx`
    - Configure with appropriate middleware
    - Set up proxy URL environment variables
 

--- a/.claude/agents/generic-provider/generic-provider-generator-t2v.md
+++ b/.claude/agents/generic-provider/generic-provider-generator-t2v.md
@@ -247,7 +247,7 @@ async function pollForCompletion(taskId: string, config: any) {
    - Export in main plugin
 
 3. **Demo Integration**:
-   - Add to `text2video` section in ai-demo.tsx
+   - Add to `text2video` section in examples/ai/src/App.tsx
    - Configure with video rate limiting middleware (typically stricter)
    - Set up environment variables for API keys
 

--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### New Features
+
+-   [image-generation] **SeedreamV4 Provider**: Added ByteDance Seedream 4.0 text-to-image provider via fal.ai for high-quality image generation with multiple size presets (square HD 2048×2048, square 1024×1024, portrait/landscape variants), custom dimensions support (1024-4096 pixels), and safety checker enabled by default
+-   [image-generation] **SeedreamV4Edit Provider**: Added ByteDance Seedream 4.0 image-to-image provider via fal.ai for advanced image editing with unified generation/editing architecture, support for multiple input images (up to 10), and full canvas quick actions support (editImage, swapBackground, styleTransfer, artistTransfer, createVariant, combineImages, remixPage, remixPageWithPrompt)
+
 ## [0.2.7] - 2025-09-26
 
 ### New Features

--- a/examples/ai/src/App.tsx
+++ b/examples/ai/src/App.tsx
@@ -229,6 +229,10 @@ function App() {
                     FalAiImage.IdeogramV3({
                       middleware: [imageRateLimitMiddleware, errorMiddleware],
                       proxyUrl: import.meta.env.VITE_FAL_AI_PROXY_URL
+                    }),
+                    FalAiImage.SeedreamV4({
+                      middleware: [imageRateLimitMiddleware, errorMiddleware],
+                      proxyUrl: import.meta.env.VITE_FAL_AI_PROXY_URL
                     })
                   ],
                   image2image: [
@@ -257,6 +261,10 @@ function App() {
                       proxyUrl: import.meta.env.VITE_FAL_AI_PROXY_URL
                     }),
                     FalAiImage.IdeogramV3Remix({
+                      middleware: [imageRateLimitMiddleware, errorMiddleware],
+                      proxyUrl: import.meta.env.VITE_FAL_AI_PROXY_URL
+                    }),
+                    FalAiImage.SeedreamV4Edit({
                       middleware: [imageRateLimitMiddleware, errorMiddleware],
                       proxyUrl: import.meta.env.VITE_FAL_AI_PROXY_URL
                     })

--- a/packages/plugin-ai-image-generation-web/README.md
+++ b/packages/plugin-ai-image-generation-web/README.md
@@ -662,7 +662,53 @@ cesdk.i18n.setTranslations({
 });
 ```
 
-#### 10. NanoBananaEdit (Image-to-Image)
+#### 10. SeedreamV4 (Text-to-Image)
+
+A powerful text-to-image model from ByteDance's Seedream 4.0 available through fal.ai:
+
+```typescript
+text2image: FalAiImage.SeedreamV4({
+  proxyUrl: 'http://your-proxy-server.com/api/proxy',
+  headers: {
+    'x-custom-header': 'value',
+    'x-client-version': '1.0.0'
+  },
+  // Optional: Configure default property values
+  properties: {
+    image_size: { default: 'square_hd' }  // Options: square_hd, square, portrait/landscape variants
+  }
+})
+```
+
+Key features:
+- High-quality image generation with ByteDance's Seedream 4.0 model
+- Multiple image size presets: square HD (2048×2048), square (1024×1024), portrait 4:3/16:9, landscape 4:3/16:9
+- Custom dimensions support (1024-4096 pixels)
+- Fast generation times
+- Safety checker enabled by default
+
+#### 11. SeedreamV4Edit (Image-to-Image)
+
+An advanced image editing model from ByteDance's Seedream 4.0 for transforming existing images:
+
+```typescript
+image2image: FalAiImage.SeedreamV4Edit({
+  proxyUrl: 'http://your-proxy-server.com/api/proxy',
+  headers: {
+    'x-custom-header': 'value',
+    'x-client-version': '1.0.0'
+  }
+})
+```
+
+Key features:
+- Unified architecture for both generation and editing
+- Supports multiple input images (up to 10)
+- Full canvas quick actions support: edit image, swap background, style transfer, artist styles, create variants, combine images, remix page
+- Maintains original image dimensions
+- Custom headers support for API requests
+
+#### 12. NanoBananaEdit (Image-to-Image)
 
 An image editing model from fal.ai that transforms existing images using text prompts:
 
@@ -1095,6 +1141,26 @@ FalAiImage.NanoBananaEdit(config: {
 })
 ```
 
+#### SeedreamV4
+
+```typescript
+FalAiImage.SeedreamV4(config: {
+  proxyUrl: string;
+  headers?: Record<string, string>;
+  debug?: boolean;
+})
+```
+
+#### SeedreamV4Edit
+
+```typescript
+FalAiImage.SeedreamV4Edit(config: {
+  proxyUrl: string;
+  headers?: Record<string, string>;
+  debug?: boolean;
+})
+```
+
 ## UI Integration
 
 The plugin automatically registers the following UI components:
@@ -1190,6 +1256,8 @@ const myImageProvider = {
   - FluxProKontextMaxEdit: `ly.img.ai.fal-ai/flux-pro/kontext/max`
   - NanoBanana: `ly.img.ai.fal-ai/nano-banana`
   - NanoBananaEdit: `ly.img.ai.fal-ai/nano-banana/edit`
+  - SeedreamV4: `ly.img.ai.fal-ai/bytedance/seedream/v4/text-to-image`
+  - SeedreamV4Edit: `ly.img.ai.fal-ai/bytedance/seedream/v4/edit`
 
 ### Asset History
 
@@ -1206,6 +1274,8 @@ Generated images are automatically stored in asset sources with the following ID
 - FluxProKontextMaxEdit: `fal-ai/flux-pro/kontext/max.history`
 - NanoBanana: `fal-ai/nano-banana.history`
 - NanoBananaEdit: `fal-ai/nano-banana/edit.history`
+- SeedreamV4: `fal-ai/bytedance/seedream/v4/text-to-image.history`
+- SeedreamV4Edit: `fal-ai/bytedance/seedream/v4/edit.history`
 
 ### Dock Integration
 

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4.constants.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4.constants.ts
@@ -1,0 +1,15 @@
+const IMAGE_SIZE_MAP: Record<string, { width: number; height: number }> = {
+  square_hd: { width: 2048, height: 2048 },
+  square: { width: 1024, height: 1024 },
+  portrait_4_3: { width: 1536, height: 2048 },
+  portrait_16_9: { width: 1152, height: 2048 },
+  landscape_4_3: { width: 2048, height: 1536 },
+  landscape_16_9: { width: 2048, height: 1152 }
+};
+
+export function getImageDimensions(id: string): {
+  width: number;
+  height: number;
+} {
+  return IMAGE_SIZE_MAP[id] || { width: 2048, height: 2048 };
+}

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4.json
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4.json
@@ -1,0 +1,327 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Fal Queue API",
+    "version": "1.0.0",
+    "description": "The Fal Queue API."
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "Fal Key"
+      }
+    },
+    "schemas": {
+      "QueueStatus": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["IN_QUEUE", "IN_PROGRESS", "COMPLETED"]
+          },
+          "request_id": { "type": "string", "description": "The request id." },
+          "response_url": {
+            "type": "string",
+            "description": "The response url."
+          },
+          "status_url": { "type": "string", "description": "The status url." },
+          "cancel_url": { "type": "string", "description": "The cancel url." },
+          "logs": {
+            "type": "object",
+            "description": "The logs.",
+            "additionalProperties": true
+          },
+          "metrics": {
+            "type": "object",
+            "description": "The metrics.",
+            "additionalProperties": true
+          },
+          "queue_position": {
+            "type": "integer",
+            "description": "The queue position."
+          }
+        },
+        "required": ["status", "request_id"]
+      },
+      "SeedreamV4Input": {
+        "title": "SeedreamV4TextToImageInput",
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "title": "Prompt",
+            "type": "string",
+            "description": "Text prompt used to generate the image",
+            "x-imgly-builder": {
+              "component": "TextArea"
+            }
+          },
+          "image_size": {
+            "anyOf": [
+              {
+                "enum": [
+                  "square_hd",
+                  "square",
+                  "portrait_4_3",
+                  "portrait_16_9",
+                  "landscape_4_3",
+                  "landscape_16_9"
+                ],
+                "type": "string"
+              },
+              { "$ref": "#/components/schemas/ImageSize" }
+            ],
+            "title": "Image Size",
+            "default": "square_hd",
+            "description": "The size of the generated image",
+            "x-imgly-enum-labels": {
+              "ImageSize": "Custom",
+              "square_hd": "Square HD",
+              "square": "Square",
+              "portrait_4_3": "Portrait 4:3",
+              "portrait_16_9": "Portrait 16:9",
+              "landscape_4_3": "Landscape 4:3",
+              "landscape_16_9": "Landscape 16:9"
+            },
+            "x-imgly-enum-icons": {
+              "square": "@imgly/plugin/formats/ratio1by1",
+              "square_hd": "@imgly/plugin/formats/ratio1by1",
+              "portrait_4_3": "@imgly/plugin/formats/ratio3by4",
+              "portrait_16_9": "@imgly/plugin/formats/ratio9by16",
+              "landscape_4_3": "@imgly/plugin/formats/ratio4by3",
+              "landscape_16_9": "@imgly/plugin/formats/ratio16by9",
+              "ImageSize": "@imgly/plugin/formats/ratioFree"
+            }
+          },
+          "num_images": {
+            "title": "Number of Images",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 6,
+            "default": 1,
+            "description": "Number of separate model generations"
+          },
+          "max_images": {
+            "title": "Max Images",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 6,
+            "default": 1,
+            "description": "Enables multi-image generation"
+          },
+          "seed": {
+            "title": "Seed",
+            "type": "integer",
+            "description": "Control image generation randomness"
+          },
+          "sync_mode": {
+            "title": "Sync Mode",
+            "type": "boolean",
+            "default": false,
+            "description": "Return media as data URI"
+          },
+          "enable_safety_checker": {
+            "title": "Enable Safety Checker",
+            "type": "boolean",
+            "default": true,
+            "description": "Enable safety checking"
+          }
+        },
+        "x-fal-order-properties": ["prompt", "image_size"],
+        "required": ["prompt"]
+      },
+      "SeedreamV4Output": {
+        "title": "SeedreamV4TextToImageOutput",
+        "type": "object",
+        "properties": {
+          "images": {
+            "title": "Images",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/File" }
+          },
+          "seed": {
+            "title": "Seed",
+            "type": "integer",
+            "description": "The seed used for generation"
+          }
+        },
+        "x-fal-order-properties": ["images", "seed"],
+        "required": ["images"]
+      },
+      "ImageSize": {
+        "title": "ImageSize",
+        "type": "object",
+        "properties": {
+          "height": {
+            "maximum": 4096,
+            "minimum": 1024,
+            "type": "integer",
+            "title": "Height",
+            "description": "The height of the generated image.",
+            "default": 2048
+          },
+          "width": {
+            "maximum": 4096,
+            "minimum": 1024,
+            "type": "integer",
+            "title": "Width",
+            "description": "The width of the generated image.",
+            "default": 2048
+          }
+        },
+        "x-fal-order-properties": ["width", "height"]
+      },
+      "File": {
+        "title": "File",
+        "type": "object",
+        "properties": {
+          "file_size": {
+            "title": "File Size",
+            "type": "integer",
+            "description": "The size of the file in bytes."
+          },
+          "file_name": {
+            "title": "File Name",
+            "type": "string",
+            "description": "The name of the file. It will be auto-generated if not provided."
+          },
+          "content_type": {
+            "title": "Content Type",
+            "type": "string",
+            "description": "The mime type of the file."
+          },
+          "url": {
+            "title": "Url",
+            "type": "string",
+            "description": "The URL where the file can be downloaded from."
+          },
+          "file_data": {
+            "format": "binary",
+            "title": "File Data",
+            "type": "string",
+            "description": "File data"
+          }
+        },
+        "x-fal-order-properties": [
+          "url",
+          "content_type",
+          "file_name",
+          "file_size",
+          "file_data"
+        ],
+        "required": ["url"]
+      }
+    }
+  },
+  "paths": {
+    "/fal-ai/bytedance/seedream/v4/text-to-image/requests/{request_id}/status": {
+      "get": {
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "description": "Request ID" }
+          },
+          {
+            "name": "logs",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "description": "Whether to include logs (`1`) in the response or not (`0`)."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request status.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/QueueStatus" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fal-ai/bytedance/seedream/v4/text-to-image/requests/{request_id}/cancel": {
+      "put": {
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "description": "Request ID" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was cancelled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the request was cancelled successfully."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fal-ai/bytedance/seedream/v4/text-to-image": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SeedreamV4Input" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The request status.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/QueueStatus" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fal-ai/bytedance/seedream/v4/text-to-image/requests/{request_id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "description": "Request ID" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result of the request.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SeedreamV4Output" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [{ "url": "https://queue.fal.run" }],
+  "security": [{ "apiKeyAuth": [] }]
+}

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4.ts
@@ -1,0 +1,83 @@
+import { type Provider, type CommonProviderConfiguration } from '@imgly/plugin-ai-generation-web';
+import SeedreamV4Schema from './SeedreamV4.json';
+import CreativeEditorSDK from '@cesdk/cesdk-js';
+import { getImageDimensions } from './SeedreamV4.constants';
+import createImageProvider from './createImageProvider';
+import { isCustomImageSize } from './utils';
+
+// Define input interface based on Seedream v4 API schema
+export interface SeedreamV4TextToImageInput {
+  prompt: string;
+  image_size?:
+    | 'square_hd'
+    | 'square'
+    | 'portrait_4_3'
+    | 'portrait_16_9'
+    | 'landscape_4_3'
+    | 'landscape_16_9'
+    | {
+        width: number;
+        height: number;
+      };
+  num_images?: number;
+  max_images?: number;
+  seed?: number;
+  sync_mode?: boolean;
+  enable_safety_checker?: boolean;
+}
+
+type SeedreamV4Output = {
+  kind: 'image';
+  url: string;
+};
+
+export function SeedreamV4(
+  config: CommonProviderConfiguration<SeedreamV4TextToImageInput, SeedreamV4Output>
+): (context: {
+  cesdk: CreativeEditorSDK;
+}) => Promise<Provider<'image', SeedreamV4TextToImageInput, SeedreamV4Output>> {
+  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
+    return getProvider(cesdk, config);
+  };
+}
+
+function getProvider(
+  cesdk: CreativeEditorSDK,
+  config: CommonProviderConfiguration<SeedreamV4TextToImageInput, SeedreamV4Output>
+): Provider<'image', SeedreamV4TextToImageInput, SeedreamV4Output> {
+  const modelKey = 'fal-ai/bytedance/seedream/v4/text-to-image';
+
+  return createImageProvider(
+    {
+      modelKey,
+      name: 'Seedream V4',
+      // @ts-ignore
+      schema: SeedreamV4Schema,
+      inputReference: '#/components/schemas/SeedreamV4Input',
+      middleware: config.middlewares ?? config.middleware ?? [],
+      headers: config.headers,
+      userFlow: 'placeholder',
+      getBlockInput: (input) => {
+        if (isCustomImageSize(input.image_size)) {
+          return Promise.resolve({
+            image: {
+              width: input.image_size.width ?? 2048,
+              height: input.image_size.height ?? 2048
+            }
+          });
+        }
+
+        const imageDimension = getImageDimensions(
+          (input.image_size as string) ?? 'square_hd'
+        );
+
+        return Promise.resolve({
+          image: imageDimension
+        });
+      }
+    },
+    config
+  );
+}
+
+export default getProvider;

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4Edit.json
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4Edit.json
@@ -1,0 +1,319 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Fal Queue API",
+    "version": "1.0.0",
+    "description": "The Fal Queue API."
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "Fal Key"
+      }
+    },
+    "schemas": {
+      "QueueStatus": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["IN_QUEUE", "IN_PROGRESS", "COMPLETED"]
+          },
+          "request_id": { "type": "string", "description": "The request id." },
+          "response_url": {
+            "type": "string",
+            "description": "The response url."
+          },
+          "status_url": { "type": "string", "description": "The status url." },
+          "cancel_url": { "type": "string", "description": "The cancel url." },
+          "logs": {
+            "type": "object",
+            "description": "The logs.",
+            "additionalProperties": true
+          },
+          "metrics": {
+            "type": "object",
+            "description": "The metrics.",
+            "additionalProperties": true
+          },
+          "queue_position": {
+            "type": "integer",
+            "description": "The queue position."
+          }
+        },
+        "required": ["status", "request_id"]
+      },
+      "SeedreamV4EditInput": {
+        "title": "SeedreamV4EditInput",
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "maxLength": 5000,
+            "type": "string",
+            "title": "Prompt",
+            "minLength": 1,
+            "description": "Text description for image editing. Describe the changes you want to make to the image.",
+            "x-imgly-builder": { "component": "TextArea" }
+          },
+          "image_url": {
+            "title": "Image URL",
+            "type": "string",
+            "description": "URL of the input image to edit"
+          },
+          "image_urls": {
+            "title": "Image URLs",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of input image URLs for editing (up to 10 images)",
+            "maxItems": 10
+          },
+          "num_images": {
+            "title": "Number of Images",
+            "type": "integer",
+            "description": "Number of images to generate",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 6
+          },
+          "image_size": {
+            "title": "Image Size",
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "Predefined image size",
+                "default": "2048x2048"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "width": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 4096
+                  },
+                  "height": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 4096
+                  }
+                },
+                "required": ["width", "height"]
+              }
+            ],
+            "description": "Size of the generated image. Can be a predefined size string or custom dimensions."
+          },
+          "max_images": {
+            "title": "Max Images",
+            "type": "integer",
+            "description": "Maximum number of images to process",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 6
+          },
+          "seed": {
+            "title": "Seed",
+            "type": "integer",
+            "description": "Random seed for reproducible results"
+          },
+          "sync_mode": {
+            "title": "Sync Mode",
+            "type": "boolean",
+            "description": "Whether to return data URI in sync mode",
+            "default": false
+          },
+          "enable_safety_checker": {
+            "title": "Enable Safety Checker",
+            "type": "boolean",
+            "description": "Enable safety checker to filter inappropriate content",
+            "default": true
+          }
+        },
+        "x-fal-order-properties": ["image_url", "prompt"],
+        "required": ["prompt", "image_urls"]
+      },
+      "SeedreamV4EditOutput": {
+        "title": "SeedreamV4EditOutput",
+        "type": "object",
+        "properties": {
+          "images": {
+            "title": "Images",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Image"
+            },
+            "description": "The generated/edited images"
+          },
+          "seed": {
+            "title": "Seed",
+            "type": "integer",
+            "description": "The seed used for generation"
+          }
+        },
+        "x-fal-order-properties": ["images", "seed"],
+        "required": ["images"]
+      },
+      "Image": {
+        "title": "Image",
+        "type": "object",
+        "properties": {
+          "file_size": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "File Size",
+            "description": "The size of the file in bytes."
+          },
+          "height": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Height",
+            "description": "The height of the image in pixels."
+          },
+          "file_name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "File Name",
+            "description": "The name of the file. It will be auto-generated if not provided."
+          },
+          "content_type": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Content Type",
+            "description": "The mime type of the file."
+          },
+          "url": {
+            "title": "Url",
+            "type": "string",
+            "description": "The URL where the file can be downloaded from."
+          },
+          "width": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Width",
+            "description": "The width of the image in pixels."
+          }
+        },
+        "description": "Represents an image file.",
+        "x-fal-order-properties": [
+          "url",
+          "content_type",
+          "file_name",
+          "file_size",
+          "width",
+          "height"
+        ],
+        "required": ["url"]
+      }
+    }
+  },
+  "paths": {
+    "/fal-ai/bytedance/seedream/v4/edit/requests/{request_id}/status": {
+      "get": {
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "description": "Request ID" }
+          },
+          {
+            "name": "logs",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "description": "Whether to include logs (`1`) in the response or not (`0`)."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request status.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/QueueStatus" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fal-ai/bytedance/seedream/v4/edit/requests/{request_id}/cancel": {
+      "put": {
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "description": "Request ID" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was cancelled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the request was cancelled successfully."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fal-ai/bytedance/seedream/v4/edit": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SeedreamV4EditInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The request status.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/QueueStatus" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fal-ai/bytedance/seedream/v4/edit/requests/{request_id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "description": "Request ID" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result of the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SeedreamV4EditOutput"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [{ "url": "https://queue.fal.run" }],
+  "security": [{ "apiKeyAuth": [] }]
+}

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4Edit.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/SeedreamV4Edit.ts
@@ -1,0 +1,191 @@
+import {
+  ImageOutput,
+  type Provider,
+  type CommonProviderConfiguration,
+  getPanelId,
+  CommonProperties
+} from '@imgly/plugin-ai-generation-web';
+import schema from './SeedreamV4Edit.json';
+import { getImageDimensionsFromURL } from '@imgly/plugin-utils';
+import CreativeEditorSDK, { MimeType } from '@cesdk/cesdk-js';
+import createImageProvider from './createImageProvider';
+
+type SeedreamV4EditInput = {
+  prompt: string;
+  image_url?: string; // For UI compatibility (single image)
+  image_urls?: string[]; // For API compatibility (up to 10 images)
+  exportFromBlockIds?: number[]; // For combineImages quick action
+  num_images?: number;
+  image_size?: string | { width: number; height: number };
+  max_images?: number;
+  seed?: number;
+  sync_mode?: boolean;
+  enable_safety_checker?: boolean;
+};
+
+export function SeedreamV4Edit(
+  config: CommonProviderConfiguration<SeedreamV4EditInput, ImageOutput>
+): (context: {
+  cesdk: CreativeEditorSDK;
+}) => Promise<Provider<'image', SeedreamV4EditInput, ImageOutput>> {
+  return async ({ cesdk }: { cesdk: CreativeEditorSDK }) => {
+    const modelKey = 'fal-ai/bytedance/seedream/v4/edit';
+
+    // Set translations
+    cesdk.i18n.setTranslations({
+      en: {
+        [`panel.${getPanelId(modelKey)}.imageSelection`]:
+          'Select Image To Edit',
+        [`panel.${modelKey}.imageSelection`]: 'Select Image To Edit',
+        [`libraries.${getPanelId(modelKey)}.history.label`]:
+          'Generated From Image'
+      }
+    });
+
+    return getProvider(cesdk, config);
+  };
+}
+
+function getProvider(
+  cesdk: CreativeEditorSDK,
+  config: CommonProviderConfiguration<SeedreamV4EditInput, ImageOutput>
+): Provider<'image', SeedreamV4EditInput, ImageOutput> {
+  const modelKey = 'fal-ai/bytedance/seedream/v4/edit';
+
+  return createImageProvider(
+    {
+      modelKey,
+      name: 'Seedream V4 Edit',
+      // @ts-ignore
+      schema,
+      inputReference: '#/components/schemas/SeedreamV4EditInput',
+      cesdk,
+      supportedQuickActions: {
+        'ly.img.editImage': {
+          mapInput: (input) => ({
+            prompt: input.prompt,
+            image_url: input.uri
+          })
+        },
+        'ly.img.swapBackground': {
+          mapInput: (input) => ({
+            prompt: input.prompt,
+            image_url: input.uri
+          })
+        },
+        'ly.img.styleTransfer': {
+          mapInput: (input) => ({
+            prompt: input.style,
+            image_url: input.uri
+          })
+        },
+        'ly.img.artistTransfer': {
+          mapInput: (input) => ({
+            prompt: input.artist,
+            image_url: input.uri
+          })
+        },
+        'ly.img.createVariant': {
+          mapInput: (input) => ({
+            prompt: input.prompt,
+            image_url: input.uri
+          })
+        },
+        'ly.img.combineImages': {
+          mapInput: (input) => ({
+            prompt: input.prompt,
+            image_urls: input.uris,
+            exportFromBlockIds: input.exportFromBlockIds
+          })
+        },
+        'ly.img.remixPage': {
+          mapInput: (input) => ({
+            prompt: input.prompt,
+            image_url: input.uri
+          })
+        },
+        'ly.img.remixPageWithPrompt': {
+          mapInput: (input) => ({
+            prompt: input.prompt,
+            image_url: input.uri
+          })
+        }
+      },
+      renderCustomProperty: CommonProperties.ImageUrl(modelKey, {
+        cesdk: cesdk,
+        propertyKey: 'image_url'
+      }),
+      middleware: [
+        // Convert image_url to image_urls array and handle exportFromBlockIds
+        async (input, options, next) => {
+          let processedInput = input;
+
+          // Handle exportFromBlockIds for combineImages quick action
+          if (input.exportFromBlockIds && input.exportFromBlockIds.length > 0) {
+            // Export blocks to image URLs
+            const imageUrls = await Promise.all(
+              input.exportFromBlockIds.map(async (blockId) => {
+                const exportedBlob = await cesdk.engine.block.export(
+                  blockId,
+                  MimeType.Jpeg,
+                  {
+                    targetHeight: 2048,
+                    targetWidth: 2048
+                  }
+                );
+                return URL.createObjectURL(exportedBlob);
+              })
+            );
+
+            processedInput = {
+              ...input,
+              image_urls: imageUrls
+            };
+            // Remove exportFromBlockIds since the API doesn't need it
+            delete processedInput.exportFromBlockIds;
+          }
+          // Convert single image_url to image_urls array if needed
+          else if (input.image_url && !input.image_urls) {
+            processedInput = {
+              ...input,
+              image_urls: [input.image_url]
+            };
+            // Remove the image_url since the API expects image_urls
+            delete processedInput.image_url;
+          }
+
+          return next(processedInput, options);
+        },
+        ...(config.middlewares ?? config.middleware ?? [])
+      ],
+      headers: config.headers,
+      getBlockInput: async (input) => {
+        // Handle both image_url and image_urls - prefer image_url for UI, fallback to image_urls
+        let imageUrl = input.image_url;
+        if (!imageUrl && input.image_urls && input.image_urls.length > 0) {
+          imageUrl = input.image_urls[0];
+        }
+
+        if (!imageUrl) {
+          throw new Error('No image URL provided');
+        }
+
+        // For multiple images, use dimensions from the first image
+        // The model will generate output based on the combined/edited result
+        const { width, height } = await getImageDimensionsFromURL(
+          imageUrl,
+          cesdk.engine
+        );
+        return Promise.resolve({
+          image: {
+            width,
+            height
+          }
+        });
+      }
+    },
+    config
+  );
+}
+
+export default getProvider;

--- a/packages/plugin-ai-image-generation-web/src/fal-ai/index.ts
+++ b/packages/plugin-ai-image-generation-web/src/fal-ai/index.ts
@@ -8,6 +8,8 @@ import { IdeogramV3Remix } from './IdeogramV3Remix';
 import { QwenImageEdit } from './QwenImageEdit';
 import { NanoBanana } from './NanoBanana';
 import { NanoBananaEdit } from './NanoBananaEdit';
+import { SeedreamV4 } from './SeedreamV4';
+import { SeedreamV4Edit } from './SeedreamV4Edit';
 
 const FalAi = {
   FluxProKontextEdit,
@@ -19,6 +21,8 @@ const FalAi = {
   NanoBanana,
   NanoBananaEdit,
   Recraft20b,
-  RecraftV3
+  RecraftV3,
+  SeedreamV4,
+  SeedreamV4Edit
 };
 export default FalAi;


### PR DESCRIPTION
## Summary

This PR adds two new AI image generation providers from ByteDance's Seedream 4.0 model via fal.ai:
- **SeedreamV4**: Text-to-image generation
- **SeedreamV4Edit**: Image-to-image editing with multi-image support

## Changes

### Provider Implementation
- Added `SeedreamV4.ts`, `SeedreamV4.json`, and `SeedreamV4.constants.ts` for text-to-image generation
- Added `SeedreamV4Edit.ts` and `SeedreamV4Edit.json` for image-to-image editing
- Both providers follow the established fal.ai provider patterns
- Exported providers from `packages/plugin-ai-image-generation-web/src/fal-ai/index.ts`

### Features

**SeedreamV4 (Text-to-Image)**:
- High-quality image generation with Seedream 4.0 model
- Multiple size presets: square HD (2048×2048), square (1024×1024), portrait/landscape variants
- Custom dimensions support (1024-4096 pixels)
- Safety checker enabled by default

**SeedreamV4Edit (Image-to-Image)**:
- Unified architecture for generation and editing
- Support for multiple input images (up to 10)
- Full canvas quick actions support:
  - editImage
  - swapBackground
  - styleTransfer
  - artistTransfer
  - createVariant
  - combineImages
  - remixPage
  - remixPageWithPrompt

### Integration
- Integrated providers in `examples/ai/src/App.tsx` with proper middleware configuration
- Updated agent documentation to reference the new `examples/ai` structure

### Documentation
- Added comprehensive documentation in `packages/plugin-ai-image-generation-web/README.md`
- Updated CHANGELOG-AI.md with provider details
- Fixed agent configuration files to reference correct demo paths

## Test Plan

- [ ] Build passes with `pnpm build`
- [ ] Type checking passes with `pnpm check:types`
- [ ] Providers work correctly in the AI demo app (`pnpm dev:ai`)
- [ ] Text-to-image generation works with SeedreamV4
- [ ] Image-to-image editing works with SeedreamV4Edit
- [ ] Quick actions function properly with SeedreamV4Edit