### PR TITLE
Fix sticker generation input types not enabled

### DIFF
--- a/CHANGELOG-AI.md
+++ b/CHANGELOG-AI.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   [sticker-generation] **Fixed Input Types Not Enabled**: Fixed an issue where the sticker generation panel would show "No input types are enabled" error by properly enabling the `fromText` and `fromImage` feature flags during plugin initialization
+
 ## [0.2.7] - 2025-09-26
 
 ### New Features

--- a/packages/plugin-ai-sticker-generation-web/src/plugin.ts
+++ b/packages/plugin-ai-sticker-generation-web/src/plugin.ts
@@ -31,6 +31,14 @@ export function StickerGeneration<I, O extends Output>(
         'ly.img.plugin-ai-sticker-generation-web.providerSelect',
         true
       );
+      cesdk.feature.enable(
+        'ly.img.plugin-ai-sticker-generation-web.fromText',
+        true
+      );
+      cesdk.feature.enable(
+        'ly.img.plugin-ai-sticker-generation-web.fromImage',
+        true
+      );
 
       const registry = ActionRegistry.get();
 


### PR DESCRIPTION
## Summary
- Fixed the sticker generation panel showing "No input types are enabled" error
- Added missing `fromText` and `fromImage` feature flag initialization
- Aligned sticker generation plugin behavior with other generation plugins

## Problem
The sticker generation plugin was not enabling the input type feature flags during initialization, causing the panel to display an error message when opened.

## Solution  
Added the missing feature enable calls for `ly.img.plugin-ai-sticker-generation-web.fromText` and `ly.img.plugin-ai-sticker-generation-web.fromImage` to match the behavior of other generation plugins like the image generation plugin.

## Test Plan
- [x] Open the AI demo app at http://localhost:5175/
- [x] Click on the AI dock button
- [x] Click on "Generate Sticker" card
- [x] Verify the sticker generation panel opens with a text input field instead of the error message
- [x] Verify sticker generation works correctly with text prompts