### PR TITLE
docs(ai-apps): update tutorial with CE.SDK best practices

### DIFF
--- a/packages/plugin-ai-apps-web/TUTORIAL.md
+++ b/packages/plugin-ai-apps-web/TUTORIAL.md
@@ -52,28 +52,23 @@ function App() {
             ref={(domElement) => {
                 if (domElement != null) {
                     CreativeEditorSDK.create(domElement, {
-                        license: 'your-license-key',
-                        callbacks: {
-                            onUpload: 'local',
-                            onExport: 'download'
-                        },
-                        ui: {
-                            elements: {
-                                navigation: {
-                                    action: {
-                                        load: true,
-                                        export: true
-                                    }
-                                }
-                            }
-                        }
+                        license: 'your-license-key'
                     }).then(async (instance) => {
                         cesdk.current = instance;
+
+                        // Add navigation bar actions
+                        instance.ui.insertNavigationBarOrderComponent('last', {
+                            id: 'ly.img.actions.navigationBar',
+                            children: [
+                                'ly.img.importScene.navigationBar',
+                                'ly.img.exportImage.navigationBar'
+                            ]
+                        });
 
                         // Add asset sources
                         await Promise.all([
                             instance.addDefaultAssetSources(),
-                            instance.addDemoAssetSources({ sceneMode: 'Video' })
+                            instance.addDemoAssetSources({ sceneMode: 'Video', withUploadAssetSources: true })
                         ]);
 
                         // Configure AI Apps dock position


### PR DESCRIPTION
## Summary
- Updated the AI Apps tutorial to align with current CE.SDK best practices
- Replaced deprecated configuration patterns with modern API calls
- Synced with documentation from the main ubq repository

## Changes
- Removed deprecated `callbacks` and `ui.elements.navigation` configuration from `CreativeEditorSDK.create()`
- Added `insertNavigationBarOrderComponent` API call for programmatic navigation bar setup
- Added `withUploadAssetSources: true` parameter to `addDemoAssetSources()` for upload capability

## Context
These changes align the tutorial with the current CE.SDK documentation standards, moving from declarative configuration to imperative API calls as recommended in the latest CE.SDK version.